### PR TITLE
Reviewer Matt: Mmonit fix - Issue #4

### DIFF
--- a/clearwater-infrastructure/etc/clearwater/scripts/mmonit
+++ b/clearwater-infrastructure/etc/clearwater/scripts/mmonit
@@ -45,21 +45,23 @@ MMONIT_CONFIG_FILE="/etc/monit/conf.d/mmonit.monit"
 MONIT_USER="admin"
 MONIT_PW="monit"
 
-# First check if we have configuration for M/Monit, exiting if not
+# Check if we have configuration for M/Monit
 if [[ -z $mmonit_hostname || -z $mmonit_username || -z $mmonit_password ]]
 then
-  echo "Not configuring M/Monit due to missing configuration"
-  # In case the configuration has changed, remove redundant 
-  # M/Monit config file
-  rm $MMONIT_CONFIG_FILE
-  exit
+  echo "Configuring monit for only localhost access"
+  cat > $MMONIT_CONFIG_FILE << EOF
+  set eventqueue basedir /var/monit/ slots 1000
+  set httpd port 2812 and use address $local_ip
+    allow 0.0.0.0/0
+EOF
+else
+  echo "Configuring monit for localhost and M/Monit access"
+  cat > $MMONIT_CONFIG_FILE << EOF
+  set eventqueue basedir /var/monit/ slots 1000
+  set mmonit http://$mmonit_username:$mmonit_password@$mmonit_hostname/collector
+  set httpd port 2812 and use address $local_ip
+    allow 0.0.0.0/0
+    allow $MONIT_USER:$MONIT_PW
+EOF
 fi
 
-# Write the file
-cat > $MMONIT_CONFIG_FILE << EOF
-set eventqueue basedir /var/monit/ slots 1000
-set mmonit http://$mmonit_username:$mmonit_password@$mmonit_hostname/collector
-set httpd port 2812 and use address $local_ip
-  allow 0.0.0.0/0
-  allow $MONIT_USER:$MONIT_PW
-EOF


### PR DESCRIPTION
Makes the mmonit.monit script smarter, such that it will not try to configured the connection to M/Monit unless it has  all the required data in /etc/clearwater/config.

See also https://github.com/Metaswitch/chef/pull/31

Testing wise, I've verified that systems using the new code do not try to connect to M/Monit when missing config from Chef. There is a slight annoyance in deploying this change, in that we need to upgrade all systems before changing the config in Chef.
