### PR TITLE
[Reviewer: Mike] Increase memcached's memory allocation (fixes #5)

### DIFF
--- a/clearwater-memcached/etc/clearwater/scripts/memcached
+++ b/clearwater-memcached/etc/clearwater/scripts/memcached
@@ -35,5 +35,7 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 . /etc/clearwater/config
-sed -e 's/^-l .*$/-l '$local_ip'/g' </etc/memcached.conf >/etc/memcached_11211.conf
+sed -e 's/^-l .*$/-l '$local_ip'/g
+        s/^-m .*$/-m 512/g
+        s/^\(# *\|\)-c.*$/-c 4096/g' </etc/memcached.conf >/etc/memcached_11211.conf
 sed -i 's/if failed host .*$/if failed host '$local_ip' port 11211 then restart/' /etc/monit/conf.d/memcached_11211.monit


### PR DESCRIPTION
Mike, please can you review my fix to the issue that memcached doesn't have enough memory (or connections) when running at high scale?  The fix is to increase the amount of memory (-m) to 512MB (which is more than enough for maxing out m1.large CPU) and number of connections (-c) to 4096 (which is enough for a 30M BHCA deployment, and might be enough for any size deployment, as number of connections tends to a limit).
