### PR TITLE
[Reviewer: Andy] Add/remove prompt information to/from all home directories

### DIFF
--- a/debian/clearwater-infrastructure.postinst
+++ b/debian/clearwater-infrastructure.postinst
@@ -66,6 +66,7 @@ case "$1" in
         for HOME_DIR in $(find /home -mindepth 1 -maxdepth 1 -type d) ; do
           add_section $HOME_DIR/.bashrc clearwater-infrastructure /etc/bash.bashrc.clearwater
         done
+        [ ! -d /etc/skel ] || add_section /etc/skel/.bashrc clearwater-infrastructure /etc/bash.bashrc.clearwater
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/clearwater-infrastructure.prerm
+++ b/debian/clearwater-infrastructure.prerm
@@ -63,6 +63,7 @@ case "$1" in
         for HOME_DIR in $(find /home -mindepth 1 -maxdepth 1 -type d) ; do
           remove_section $HOME_DIR/.bashrc clearwater-infrastructure
         done
+        [ ! -d /etc/skel ] || remove_section /etc/skel/.bashrc clearwater-infrastructure
     ;;
 
     failed-upgrade)


### PR DESCRIPTION
Andy, please can you review this fix to remove hard-coded references to the ubuntu user.  We now add/remove our custom prompt to/from all users (who have home directories).  I've tested this live.
