### PR TITLE
[Reviewer: Andy] Don't destroy /etc/clearwater/config if sed expression is bad

### DIFF
--- a/debian/clearwater-auto-config-generic.init.d
+++ b/debian/clearwater-auto-config-generic.init.d
@@ -54,9 +54,8 @@ do_auto_config()
 
   sed -e 's/^local_ip=.*$/local_ip='$ip'/g
           s/^public_ip=.*$/public_ip='$ip'/g
-          s/^public_hostname=.*$/public_hostname='$ip'/g' < /etc/clearwater/config > /tmp/clearwater.config.$$
+          s/^public_hostname=.*$/public_hostname='$ip'/g' -i $config
 
-  mv /tmp/clearwater.config.$$ /etc/clearwater/config
   # Sprout will replace the cluster-settings file with something appropriate when it starts
   rm -f /etc/clearwater/cluster_settings
 }


### PR DESCRIPTION
Andy, please can you review my fix?  Someone turned up an all-in-one node on a non-DHCP network.  We don't expect this to work.  Unfortunately, this caused a bad sed expression, which meant that we wrote nothing to /tmp/clearwater.config.$$.  We then moved this back over /etc/clearwater/config, corrupting it.  Instead, I now use -i to edit /etc/clearwater/config in place.  In particular, this means that if the sed expression is bad, we don't touch /etc/clearwater/config.  I've tested this live.
