### PR TITLE
[Reviewer: Matt] Update snmpd.conf to restrict access and to add in the custom Clearwater...

### DIFF
--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -44,12 +44,12 @@ agentAddress udp:161,udp6:[::1]:161
                                                  #  system + hrSystem groups only
 #view   systemonly  included   .1.3.6.1.2.1.1
 #view   systemonly  included   .1.3.6.1.2.1.25.1
-view   systemonly  included   .1
+#view   systemonly  included   .1
 
                                                  #  Full access from the local host
 #rocommunity public  localhost
                                                  #  Default access to basic system info
- rocommunity public  default    -V systemonly
+# rocommunity public  default    -V systemonly
 
                                                  #  Full access from an example network
                                                  #     Adjust this network address to match your local
@@ -124,7 +124,7 @@ load   12 10 5
 #
 
                                     #   send SNMPv1  traps
- trapsink     localhost public
+# trapsink     localhost public
                                     #   send SNMPv2c traps
 #trap2sink    localhost public
                                     #   send SNMPv2c INFORMs
@@ -155,8 +155,8 @@ linkUpDownNotifications  yes
 #
 #  Arbitrary extension commands
 #
- extend    test1   /bin/echo  Hello, world!
- extend-sh test2   echo Hello, world! ; echo Hi there ; exit 35
+# extend    test1   /bin/echo  Hello, world!
+# extend-sh test2   echo Hello, world! ; echo Hi there ; exit 35
 #extend-sh test3   /bin/sh /tmp/shtest
 
 #  Note that this last entry requires the script '/tmp/shtest' to be created first,
@@ -192,3 +192,10 @@ linkUpDownNotifications  yes
                                            #  Listen for network connections (from localhost)
                                            #    rather than the default named socket /var/agentx/master
 #agentXSocket    tcp:localhost:705
+
+rocommunity clearwater 0.0.0.0/0 -V clearwater
+view clearwater included .1.3.6.1.4.1.2021.4
+view clearwater included .1.3.6.1.4.1.2021.11
+view clearwater included .1.2.826.0.1.1578918.9
+dlmod sprout_handler /usr/lib/clearwater/sprout_handler.so
+dlmod bono_handler /usr/lib/clearwater/bono_handler.so


### PR DESCRIPTION
Matt,

This change makes the Clearwater SNMP community we defined the only supported one, and closes off more general SNMP access.
