### PR TITLE
[Reviewer: Rob] Bind monit's management interface to localhost - without mmonit, it's only usable locally anyway

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/mmonit
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/mmonit
@@ -51,7 +51,7 @@ then
   echo "Configuring monit for only localhost access"
   cat > $MMONIT_CONFIG_FILE << EOF
   set eventqueue basedir /var/monit/ slots 1000
-  set httpd port 2812 and use address $local_ip
+  set httpd port 2812 and use address localhost
     allow 0.0.0.0/0
 EOF
 else


### PR DESCRIPTION
Rob,

Please can you review my fix to make mmonit bind its management interface to localhost.  This is primarily to work around an issue that monit doesn't support binding to IPv6 addresses, but I think it's sensible anyway because it's just a security exposure to have this on a non-localhost interface (unless mmonit is enabled, which is a separate branch anyway).  This does mean that we can't support mmonit with IPv6, but that's a much wider issue than ours (I don't believe mmonit supports IPv6 at all) and anyway mmonit support seems to be becoming less important.

Matt
