### PR TITLE
Pass options through to apt-get install for clearwater-upgrade

### DIFF
--- a/clearwater-infrastructure/usr/bin/clearwater-upgrade
+++ b/clearwater-infrastructure/usr/bin/clearwater-upgrade
@@ -1,3 +1,3 @@
 #!/bin/bash
 apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" &&
-apt-get install --only-upgrade $(dpkg-query -W -f='${PackageSpec} ${Maintainer}\n' | grep " Project Clearwater Maintainers " | cut -d ' ' -f 1)
+apt-get install "$@" --only-upgrade $(dpkg-query -W -f='${PackageSpec} ${Maintainer}\n' | grep " Project Clearwater Maintainers " | cut -d ' ' -f 1)


### PR DESCRIPTION
Tested with a homestead that a) 'clearwater-upgrade' prompts you at all the normal points and b) 'clearwater-upgrade -y --force-yes' just gets it done
