### PR TITLE
[Reviewer: Matt][From: Alex] Prevent monit from spuriously restarting sprout

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip
@@ -55,7 +55,7 @@ sip_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
 #
 # The -q option keeps netcat around for 1 second after sending the OPTIONS to
 # allow the pollee time to send a response before the connection is closed.
-nc -v -C -q 1 $local_ip $port <<EOF 2> /tmp/poll-sip.nc.stderr.$$ | tee /tmp/poll-sip.nc.stdout.$$ | head -1 | egrep -q "^SIP/2.0 200"
+nc -v -C -w 2 -q 1 $local_ip $port <<EOF 2> /tmp/poll-sip.nc.stderr.$$ | tee /tmp/poll-sip.nc.stdout.$$ | head -1 | egrep -q "^SIP/2.0 200"
 OPTIONS sip:poll-sip@$sip_ip:$port SIP/2.0
 Via: SIP/2.0/TCP $sip_ip;rport;branch=z9hG4bK-$id
 Max-Forwards: 2


### PR DESCRIPTION
Matt please can you review this change that fixes #50. Should hopefully be self explanatory. 

I never got to the bottom of why we saw issue 50 on openstack and not amazon. To be sure I have tested on both as follows:
-  Sprout running (not monitored). Run poll_sprout.sh 20 times and check it returns 0 each time. 
-  Sprout stopped (not monitored). Run poll_sprout.sh 20 times and check it returns 1 each time (and gives error message).  
