### PR TITLE
Reviewer Matt: Enable first level of verbose logging on memcached - errors/warnings only

### DIFF
--- a/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
@@ -50,4 +50,5 @@ fi
 
 sed -e 's/^-l .*$/-l '$listen_address'/g
         s/^-m .*$/-m 512/g
+        s/^# *-v *$/-v/g
         s/^\(# *\|\)-c.*$/-c 4096/g' </etc/memcached.conf >/etc/memcached_11211.conf


### PR DESCRIPTION
Matt

Can you review this update to enable logging on memcached.  This just uncomments the -v line in the configuration file.  I've tested it live by copying the updated script on to a sprout system, running the script and restarting memcached.

If you're interested in (or worried about) what this will log, see http://docs.oracle.com/cd/E17952_01/refman-5.6-en/ha-memcached-using-logs.html for details.

Mike
