### PR TITLE
[Reviewer: Alex] Add support for external IPv6 connectivity to snmpd

### DIFF
--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -14,7 +14,7 @@
 #  Listen for connections from the local system only
 #agentAddress  udp:127.0.0.1:161
 #  Listen for connections on all interfaces (both IPv4 *and* IPv6)
-agentAddress udp:161,udp6:[::1]:161
+agentAddress udp:161,udp6:[::]:161
 
 
 
@@ -194,6 +194,7 @@ linkUpDownNotifications  yes
 #agentXSocket    tcp:localhost:705
 
 rocommunity clearwater 0.0.0.0/0 -V clearwater
+rocommunity6 clearwater ::/0 -V clearwater
 
 # UCD-SNMP-MIB memory stats
 view clearwater included .1.3.6.1.4.1.2021.4


### PR DESCRIPTION
Updates to snmpd.conf to allow external IPv6 read-only access to the supported clearwater MIBs. 
