### PR TITLE
[Reviewer Matt] Treat overload responses as expected

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip
@@ -55,7 +55,7 @@ sip_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
 #
 # The -q option keeps netcat around for 1 second after sending the OPTIONS to
 # allow the pollee time to send a response before the connection is closed.
-nc -v -C -w 2 -q 1 $local_ip $port <<EOF 2> /tmp/poll-sip.nc.stderr.$$ | tee /tmp/poll-sip.nc.stdout.$$ | head -1 | egrep -q "^SIP/2.0 200"
+nc -v -C -w 2 -q 1 $local_ip $port <<EOF 2> /tmp/poll-sip.nc.stderr.$$ | tee /tmp/poll-sip.nc.stdout.$$ | head -1 | egrep -q "^SIP/2.0 (200|503)"
 OPTIONS sip:poll-sip@$sip_ip:$port SIP/2.0
 Via: SIP/2.0/TCP $sip_ip;rport;branch=z9hG4bK-$id
 Max-Forwards: 2


### PR DESCRIPTION
Matt

The last part of the puzzle - this changes poll-sip to treat 503 as an expected response (ie. that indicates that bono or sprout are behaving as expected).

Mike
