### PR TITLE
[Reviewer: Ellie] Log more information when poll-sip fails

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip
@@ -76,7 +76,9 @@ rc=$?
 # Check the return code and log if appropriate
 if [ $rc != 0 ] ; then
   echo SIP poll failed to $sip_ip:$port with Call-ID poll-sip-$id at $when_nc_started >&2
+  echo "stderr was:"                    >&2
   cat /tmp/poll-sip.nc.stderr.$$        >&2
+  echo "stdout was:"                    >&2
   cat /tmp/poll-sip.nc.stdout.$$        >&2
 fi
 rm -f /tmp/poll-sip.nc.stderr.$$ /tmp/poll-sip.nc.stdout.$$


### PR DESCRIPTION
This change logs out the Call-ID and the time the OPTIONS poll was sent when a poll-sip request fails. This should make it easier to hunt through the Sprout logs for failed polls.

The resulting log is:

[UTC Aug 14 11:36:27] error    : 'poll_sprout' status failed (1) for /usr/share/clearwater/bin/poll_sprout.sh. Error: SIP poll failed to 10.238.242.172:5054 with Call-ID poll-sip-761512 at 2014-08-14 11:36:22.894016854+00:00
stderr was:
nc: connect to 10.238.242.172 port 5054 (tcp) failed: Connection refused
stdout was:
..
