### PR TITLE
[Reviewer: Andy] Make upstream_hostname match sprout_hostname (fixes #98)

### DIFF
--- a/clearwater-auto-config/etc/clearwater/config
+++ b/clearwater-auto-config/etc/clearwater/config
@@ -17,6 +17,9 @@ smtp_username=username
 smtp_password=password
 email_recovery_sender=clearwater@example.com
 
+# I-CSCF/S-CSCF configuration
+upstream_hostname=
+
 # Keys
 signup_key=secret
 turn_workaround=secret

--- a/debian/clearwater-auto-config-aws.init.d
+++ b/debian/clearwater-auto-config-aws.init.d
@@ -59,11 +59,11 @@ do_auto_config()
           s/^public_ip=.*$/public_ip='$public_ip'/g
           s/^public_hostname=.*$/public_hostname='$public_hostname'/g
           s/^sprout_hostname=.*$/sprout_hostname='$public_hostname'/g
-          s/^xdms_hostname=.*$/xdms_hostname='$local_ip':7888/g
-          s/^hs_hostname=.*$/hs_hostname='$local_ip':8888/g
+          s/^xdms_hostname=.*$/xdms_hostname='$public_hostname':7888/g
+          s/^hs_hostname=.*$/hs_hostname='$public_hostname':8888/g
           s/^chronos_hostname=.*$/chronos_hostname='$local_ip':7253/g
-          s/^hs_provisioning_hostname=.*$/hs_provisioning_hostname='$local_ip':8889/g
-          s/^upstream_hostname=.*$/upstream_hostname='$local_ip'/g' < /etc/clearwater/config > /etc/clearwater/config2
+          s/^hs_provisioning_hostname=.*$/hs_provisioning_hostname='$public_hostname':8889/g
+          s/^upstream_hostname=.*$/upstream_hostname='$public_hostname'/g' < /etc/clearwater/config > /etc/clearwater/config2
 
   rm /etc/clearwater/config
   mv /etc/clearwater/config2 /etc/clearwater/config


### PR DESCRIPTION
Andy,

Please can you review this fix to make `upstream_hostname` match `sprout_hostname` on all-in-one nodes.  This ensures that sprout recognizes itself in the Route header.

As well as fixing the direct issue, I've also
-   added upstream_hostname to the OVF /etc/clearwater/config, so that at least it behaves the same as AWS
-   fixed up AWS's other parameters to use hostnames rather than IPs where applicable.

I've live-tested for AMI but not (yet) for OVF.

Matt
