### PR TITLE
Reviewer Andy - Use 14.04-specific version of package query function as required by diagnostics and login scripts 

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -85,12 +85,23 @@ copy_to_dump()
 }
 
 
+# Get the version of Ubuntu we are running
+get_ubuntu_version()
+{
+  lsb_release -a 2>&1 | grep "^Release:" | cut -f 2
+}
+
 # List all the clearwater packages installed.
 clearwater_packages()
 {
-  dpkg-query -W -f='${PackageSpec} ${Maintainer}\n' | grep " Project Clearwater Maintainers " | cut -d ' ' -f 1
+  ub_version=$(get_ubuntu_version)
+  if [[ "$ub_version" == 12\.04* ]]
+  then
+    dpkg-query -W -f='${PackageSpec} ${Maintainer}\n' | grep " Project Clearwater Maintainers " | cut -d ' ' -f 1
+  else
+    dpkg-query -W -f='${binary:Package} ${Maintainer}\n' | grep " Project Clearwater Maintainers " | cut -d ' ' -f 1
+  fi
 }
-
 
 # Get information about all the packages installed.
 get_package_info()
@@ -566,7 +577,7 @@ do
   (cd $DUMPS_DIR; tar -pcz -f $CURRENT_DUMP_ARCHIVE $CURRENT_DUMP)
   log "Diagnostic archive $CURRENT_DUMP_ARCHIVE created"
   rm -rf "$CURRENT_DUMP_DIR"
-  
+
   mv $CURRENT_DUMP_ARCHIVE $FINAL_DUMP_ARCHIVE
 
   # We should have dealt with all the trigger files by now, unless there are

--- a/clearwater-infrastructure/etc/bash.bashrc.clearwater
+++ b/clearwater-infrastructure/etc/bash.bashrc.clearwater
@@ -1,5 +1,23 @@
+# Get the version of Ubuntu we are running
+get_ubuntu_version()
+{
+  lsb_release -a 2>&1 | grep "^Release:" | cut -f 2
+}
+
+# List all the packages installed.
+packages()
+{
+  ub_version=$(get_ubuntu_version)
+  if [[ "$ub_version" == 12\.04* ]]
+  then
+    dpkg-query -W -f='${PackageSpec}\n'
+  else
+    dpkg-query -W -f='${binary:Package}\n'
+  fi
+}
+
 type=$(. /etc/clearwater/config
-       dpkg-query -W -f='${PackageSpec}\n' |
+       for package in $(packages); do echo $package; done |
        egrep '^(bono|clearwater-sip-stress|ellis|homer|homestead|sprout|ralf)$' |
        sed -e 's/clearwater-sip-stress/sipp/g' |
        tr "\\n" "-" |
@@ -17,3 +35,4 @@ else
     PS1='${debian_chroot:+($debian_chroot)}['$type$node_idx']\u@\h:\w\$ '
 fi
 unset type node_idx
+


### PR DESCRIPTION
Fixes the use of dpkg-query in the diags monitor and in the bash.bashrc script to allow for the fact that parameters are different on Ubuntu 14.04

Tested on both 12.04 and 14.04 systems to check that both scripts now do the right thing (i.e. set up PS1 with the node type and determine package info respectively)

(In response to Dougs comment below I said "I did try that, but it didn't work - the following egrep didn't pick up the required package names, presumably because the output from packages is not LF separated. Hence the explicit echo of the packages one at a time".  For some reason, github has dropped my comments from this pull)
