### PR TITLE
Add monit monitoring for clearwater-diags-monitor

### DIFF
--- a/clearwater-diags-monitor/etc/monit/conf.d/clearwater-diags-monitor.monit
+++ b/clearwater-diags-monitor/etc/monit/conf.d/clearwater-diags-monitor.monit
@@ -1,0 +1,6 @@
+# Monitor the service's PID file.
+
+check process clearwater_diags_monitor with pidfile "/var/run/clearwater_diags_monitor.pid"
+  start = "/etc/init.d/clearwater-diags-monitor start"
+  stop  = "/etc/init.d/clearwater-diags-monitor stop"
+

--- a/debian/clearwater-diags-monitor.postinst
+++ b/debian/clearwater-diags-monitor.postinst
@@ -69,6 +69,7 @@ case "$1" in
         chmod a+rwx /var/clearwater-diags-monitor/dumps
 
         chmod a+x /usr/share/clearwater/bin/gather_diags
+        reload clearwater-monit || true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/clearwater-infrastructure/issues/87. Tested by upgrading, killing off the diags monitor, and verifying that it is restarted and I can run gather_diags successfully.
