### PR TITLE
Reviewer Matt - Use Package rather than PackageSpec for 14.04 compatibility

### DIFF
--- a/clearwater-infrastructure/usr/bin/clearwater-upgrade
+++ b/clearwater-infrastructure/usr/bin/clearwater-upgrade
@@ -1,3 +1,3 @@
 #!/bin/bash
 apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" &&
-apt-get install "$@" --only-upgrade $(dpkg-query -W -f='${PackageSpec} ${Maintainer}\n' | grep " Project Clearwater Maintainers " | cut -d ' ' -f 1)
+apt-get install "$@" --only-upgrade $(dpkg-query -W -f='${Package} ${Maintainer}\n' | grep " Project Clearwater Maintainers " | cut -d ' ' -f 1)


### PR DESCRIPTION
This is the same change we've made in `.bashrc` and the diags collection code.  Tested on a live 14.04 system.
