### PR TITLE
[Reviewer: Matt] Use install instead of mv

### DIFF
--- a/debian/clearwater-memcached-extra.postinst
+++ b/debian/clearwater-memcached-extra.postinst
@@ -53,7 +53,7 @@ set -e
 
 case "$1" in
     configure)
-        mv /usr/share/clearwater/infrastructure/conf/memcached_11212.monit /etc/monit/conf.d/
+        install /usr/share/clearwater/infrastructure/conf/memcached_11212.monit /etc/monit/conf.d/
         /usr/share/clearwater/infrastructure/scripts/memcached-extra
         /etc/init.d/memcached restart 11212
         [ ! -x /etc/init.d/clearwater-secure-connections ] || /etc/init.d/clearwater-secure-connections reload

--- a/debian/clearwater-memcached.postinst
+++ b/debian/clearwater-memcached.postinst
@@ -53,7 +53,7 @@ set -e
 
 case "$1" in
     configure)
-        mv /usr/share/clearwater/infrastructure/conf/memcached_11211.monit /etc/monit/conf.d/
+        install /usr/share/clearwater/infrastructure/conf/memcached_11211.monit /etc/monit/conf.d/
         /usr/share/clearwater/infrastructure/scripts/memcached
         /etc/init.d/memcached restart 11211
         [ ! -x /etc/init.d/clearwater-secure-connections ] || /etc/init.d/clearwater-secure-connections reload


### PR DESCRIPTION
Can you review this change to use install instead of mv, to stop clearwater-memcahed installs from always failing if they've failed once before

Fixes https://github.com/Metaswitch/sprout/issues/898
