### PR TITLE
[Reviewer: Matt] Don't rewrite /etc/init.d/memcached if it doesn't exist yet

### DIFF
--- a/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
@@ -49,51 +49,60 @@ then
   listen_address=$(/usr/share/clearwater/bin/ipv6_to_hostname.py $local_ip)
 fi
 
-sed -e 's/^-l .*$/-l '$listen_address'/g
-        s/^-m .*$/-m 512/g
-        s/^# *-v *$/-v/g
-        s/^\(# *\|\)-c.*$/-c 4096/g' </etc/memcached.conf >/etc/memcached_11211.conf
-
-# Update init.d script to run daemon in context of $namespace_prefix
-
-[ -z $signaling_namespace ] || namespace_prefix="ip netns exec $signaling_namespace"
-
-INITD_TEMP=$(mktemp -t $NAME-initd.XXXXXX) || exit 1
-
-sed 's/^\(\s\{1,\}\)\(\<start-stop-daemon\>.*--\<start\>.*\)$/\1$namespace_prefix \2 # clearwater-infrastructure/' $INITD_PATH > $INITD_TEMP
-
-if ! cmp -s $INITD_PATH $INITD_TEMP
+# This script can be run during clearwater-infrastructure's configure
+# phase, which happens before the memcached configure phase which
+# creates /etc/init.d/memcached. To guard against this, only run the
+# following code if /etc/init.d/memcached exists.
+#
+# TODO: rework this to not modify /etc/init.d/memcached, as this will
+# cause conflicts when /etc/init.d/memcached is updated.
+if [ -e $INITD_PATH ]
 then
-  # initd script update needed, so copy the $namespace_prefix mod
-  cp $INITD_TEMP $INITD_PATH
+  sed -e 's/^-l .*$/-l '$listen_address'/g
+          s/^-m .*$/-m 512/g
+          s/^# *-v *$/-v/g
+          s/^\(# *\|\)-c.*$/-c 4096/g' </etc/memcached.conf >/etc/memcached_11211.conf
+
+  # Update init.d script to run daemon in context of $namespace_prefix
+
+  [ -z $signaling_namespace ] || namespace_prefix="ip netns exec $signaling_namespace"
+
+  INITD_TEMP=$(mktemp -t $NAME-initd.XXXXXX) || exit 1
+
+  sed 's/^\(\s\{1,\}\)\(\<start-stop-daemon\>.*--\<start\>.*\)$/\1$namespace_prefix \2 # clearwater-infrastructure/' $INITD_PATH > $INITD_TEMP
+
+  if ! cmp -s $INITD_PATH $INITD_TEMP
+  then
+      # initd script update needed, so copy the $namespace_prefix mod
+      cp $INITD_TEMP $INITD_PATH
+  fi
+
+  rm $INITD_TEMP
+
+
+  # Update default configuration with $namespace_prefix if needed
+
+  DEFAULT_TEMP=$(mktemp -t $NAME-default.XXXXXX) || exit 1
+
+  if [ -f $DEFAULT_PATH ]
+  then
+    cat $DEFAULT_PATH | grep -v "# clearwater-infrastructure" > $DEFAULT_TEMP
+  else
+    touch $DEFAULT_TEMP
+    chmod +r $DEFAULT_TEMP
+  fi
+
+  echo "namespace_prefix=\"$namespace_prefix\" # clearwater-infrastructure" >> $DEFAULT_TEMP
+
+  # Compare files to see if action is needed. If the source file does
+  # not exist cmp will return non-zero and we will create it.
+  if ! cmp -s $DEFAULT_PATH $DEFAULT_TEMP
+  then
+    # default configuration update needed, so copy the change and
+    # restart the service
+    cp $DEFAULT_TEMP $DEFAULT_PATH
+    service $NAME stop
+  fi
+
+  rm $DEFAULT_TEMP
 fi
-
-rm $INITD_TEMP
-
-
-# Update default configuration with $namespace_prefix if needed
-
-DEFAULT_TEMP=$(mktemp -t $NAME-default.XXXXXX) || exit 1
-
-if [ -f $DEFAULT_PATH ]
-then
-  cat $DEFAULT_PATH | grep -v "# clearwater-infrastructure" > $DEFAULT_TEMP
-else
-  touch $DEFAULT_TEMP
-  chmod +r $DEFAULT_TEMP
-fi
-
-echo "namespace_prefix=\"$namespace_prefix\" # clearwater-infrastructure" >> $DEFAULT_TEMP
-
-# Compare files to see if action is needed. If the source file does
-# not exist cmp will return non-zero and we will create it.
-if ! cmp -s $DEFAULT_PATH $DEFAULT_TEMP
-then
-  # default configuration update needed, so copy the change and
-  # restart the service
-  cp $DEFAULT_TEMP $DEFAULT_PATH
-  service $NAME stop
-fi
-
-rm $DEFAULT_TEMP
-


### PR DESCRIPTION
I'm currently testing manual install of Sprout with this, but can you review in parallel with that? Mitigates #121 for now but isn't a completely future-proof fix.

This is mostly indentation, so I recommend `?w=1`.