### PR TITLE
Reviewer AMC: Create dump directories correctly again

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -545,12 +545,14 @@ do
 
   for diags_script in $scripts
   do
-    # Give all the scripts their own subdirectory to write diags to (to stop
-    # them from overwriting each other's diags).
-    CURRENT_DUMP_DIR=$CURRENT_DUMP_DIR/$(basename $diags_script);
-    mkdir $CURRENT_DUMP_DIR;
+    (
+      # Give all the scripts their own subdirectory to write diags to (to stop
+      # them from overwriting each other's diags).
+      CURRENT_DUMP_DIR=$CURRENT_DUMP_DIR/$(basename $diags_script);
+      mkdir $CURRENT_DUMP_DIR;
 
-    . $diags_script
+      . $diags_script
+    )
   done
 
   # Copy this script to the dump file so we can tell what diags /should/ have


### PR DESCRIPTION
Add those brackets you deleted back into the diags script so that the CURRENT_DUMP_DIR isn't changed beyond the scope of the loop

I ran bash -n over the script to check I hadn't messed up the syntax but im not intending on doing any more testing.

Thanks.