### PR TITLE
[DO NOT MERGE] Reviewer RKD: Diags monitor fixes

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -413,11 +413,17 @@ log "clearwater-diags-monitor starting"
 
 if [ ! -z $signaling_namespace ] && [ $EUID -ne 0 ]
 then
-    echo "When using multiple networks, diags collection must be run as root"
-    exit 2
+  echo "When using multiple networks, diags collection must be run as root"
+  exit 2
 fi
 
 cd $CRASH_DIR
+
+if [ $? -ne 0 ]; then
+  echo "Crash directory didn't exist, creating"
+  mkdir -p $CRASH_DIR
+  cd $CRASH_DIR
+fi
 
 while true
 do
@@ -441,7 +447,7 @@ do
   #
   # Note the filenames are currently space separated, so use tr to put them each
   # on one line.
-  triggers=$(echo $trigger_files | tr ' ' '\n' | awk 'BEGIN{FS="."} {print $2}' | sort | uniq)
+  triggers=$(echo $trigger_files | tr ' ' '\n' | awk 'BEGIN{FS="."} /^core/{print $2}' | sort | uniq)
 
   if [ -z "$triggers" ]
   then

--- a/debian/clearwater-diags-monitor.postinst
+++ b/debian/clearwater-diags-monitor.postinst
@@ -62,11 +62,11 @@ case "$1" in
 
         # Create the temporary diagnostics directory and give it appropriate permissions.
         mkdir -p /var/clearwater-diags-monitor/tmp
-        chmod a+rwx /var/clearwater-diags-monitor/tmp
+        chmod 755 /var/clearwater-diags-monitor/tmp
 
         # Do the same for the dumps directory.
         mkdir -p /var/clearwater-diags-monitor/dumps
-        chmod a+rwx /var/clearwater-diags-monitor/dumps
+        chmod 755 /var/clearwater-diags-monitor/dumps
 
         chmod a+x /usr/share/clearwater/bin/gather_diags
         reload clearwater-monit || true

--- a/debian/clearwater-diags-monitor.prerm
+++ b/debian/clearwater-diags-monitor.prerm
@@ -60,9 +60,11 @@ case "$1" in
         [ ! -f /etc/clearwater/diags-monitor/sysstat.old ] || cp -p /etc/clearwater/diags-monitor/sysstat.old /etc/default/sysstat
         rm -f /etc/clearwater/diags-monitor/sysstat.old
 
-        # Remove the temporary diagnostics directory.  Do not remove the dumps
-        # directory, we don't want to delete diags when we upgrade this package.
-        rm -rf /var/clearwater-diags-monitor/tmp
+        if [ $1 != "upgrade" ]; then
+          # Remove the temporary diagnostics directory.  Do not remove the dumps
+          # directory, we don't want to delete diags.
+          rm -rf /var/clearwater-diags-monitor/tmp
+        fi
     ;;
 
     failed-upgrade)


### PR DESCRIPTION
Hi Rob,

Please can you review this pull request? It contains fixes for https://github.com/Metaswitch/clearwater-infrastructure/issues/129 and https://github.com/Metaswitch/clearwater-infrastructure/issues/40.

We've discussed the three changes I've made for https://github.com/Metaswitch/clearwater-infrastructure/issues/129. They are the following - create the crash directory if we fail to cd into it because it doesn't exist, check the word core is in the supposed core file, and don't remove the tmp crash directory on upgrade.

I just changed the permissions on the files for https://github.com/Metaswitch/clearwater-infrastructure/issues/40 whilst I was making changes to the diags monitor. I'll update the doc mentioned in the issue if you're happy with it.

I've done some testing. I've checked the change to check on the word by running that line on it's own against various inputs. I've also upgraded the clearwater-diags-monitor on an active AIO node to the package with my changes, and created a crash. The dump was created correctly.

Not merging until after you've finished cutting the release.

Thanks,
Graeme