### PR TITLE
Reviewer RKD: Never timeout memcached

### DIFF
--- a/clearwater-memcached/usr/share/clearwater/infrastructure/conf/memcached_11211.monit
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/conf/memcached_11211.monit
@@ -21,9 +21,6 @@ check process memcached with pidfile "/var/run/memcached_11211.pid"
   if cpu usage > 98% for 5 cycles
      then restart
 
-  if 2 restarts within 3 cycles
-     then timeout
-
   if uptime < 30 seconds
      then exec "/bin/true"
      else if succeeded


### PR DESCRIPTION
Oh hey there Rob,

Can you review this change to our memcached monit file. In short, timing out memcached (which I think is the equivalent of unmonitoring it whatever state it's in) is just giving up and is never a good idea, so let's not do it. At the moment I think we're doing this if the poll_memcached script fails two out of three times.

I'll hold off merging until the release is cut.

Thanks,
Graeme

