### PR TITLE
[No reviewer] Revert file permissions

### DIFF
--- a/debian/clearwater-diags-monitor.postinst
+++ b/debian/clearwater-diags-monitor.postinst
@@ -62,11 +62,11 @@ case "$1" in
 
         # Create the temporary diagnostics directory and give it appropriate permissions.
         mkdir -p /var/clearwater-diags-monitor/tmp
-        chmod 755 /var/clearwater-diags-monitor/tmp
+        chmod a+rwx /var/clearwater-diags-monitor/tmp
 
         # Do the same for the dumps directory.
         mkdir -p /var/clearwater-diags-monitor/dumps
-        chmod 755 /var/clearwater-diags-monitor/dumps
+        chmod a+rwx /var/clearwater-diags-monitor/dumps
 
         chmod a+x /usr/share/clearwater/bin/gather_diags
 


### PR DESCRIPTION
This reverts changing the file permissions for the clearwater diags monitor as Ellis/Homer/Homestead-prov needed it. 

Linked to #40 