### PR TITLE
[Reviewer: Ellie] Sensible output from 'service clearwater-infrastructure status'

### DIFF
--- a/debian/clearwater-infrastructure.init.d
+++ b/debian/clearwater-infrastructure.init.d
@@ -113,7 +113,7 @@ case "$1" in
         esac
         ;;
   status)
-       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+      echo "clearwater-infrastructure is not a long-running daemon so does not have a 'status' command"
        ;;
   reload|force-reload)
         log_daemon_msg "Reloading $DESC" "$NAME"

--- a/debian/clearwater-infrastructure.init.d
+++ b/debian/clearwater-infrastructure.init.d
@@ -113,8 +113,8 @@ case "$1" in
         esac
         ;;
   status)
-      echo "clearwater-infrastructure is not a long-running daemon so does not have a 'status' command"
-       ;;
+        echo "clearwater-infrastructure is not a long-running daemon so does not have a 'status' command"
+        ;;
   reload|force-reload)
         log_daemon_msg "Reloading $DESC" "$NAME"
         do_reload


### PR DESCRIPTION
Fixes #105 . Tested:

```
[homestead-1]ubuntu@ec2-54-196-221-53:~$ sudo service clearwater-infrastructure status
clearwater-infrastructure is not a long-running daemon so does not have a 'status' command
[homestead-1]ubuntu@ec2-54-196-221-53:~$
```

(@nicolemcp, FYI.)