### PR TITLE
Reviewer AMC: Remove single quotes from memcached conf file

### DIFF
--- a/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
@@ -59,7 +59,7 @@ fi
 if [ -e $INITD_PATH ]
 then
   sed -e 's/^-l .*$/-l '$listen_address'/g'\
-      -e "s/^-m .*$/-e 'ignore_vbucket=true;cache_size=512000000'/g"\
+      -e "s/^-m .*$/-e ignore_vbucket=true;cache_size=512000000/g"\
       -e 's/^# *-v *$/-v/g'\
       -e 's/^\(# *\|\)-c.*$/-c 4096/g' </etc/memcached.conf >/etc/memcached_11211.conf
 


### PR DESCRIPTION
As it says. Needed due to these changes - https://github.com/Metaswitch/memcached/pull/2.