### PR TITLE
[Reviewer: Andy] Fix the version of memcached clearwater-memcached depends on

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Description: Common infrastructure for all Clearwater servers
 
 Package: clearwater-memcached
 Architecture: all
-Depends: clearwater-infrastructure, memcached (>= 1.6)
+Depends: clearwater-infrastructure, memcached (= 1.6.00-0clearwater0.2)
 Conflicts: clearwater-infinispan
 Suggests: clearwater-secure-connections
 Description: memcached configured for Clearwater


### PR DESCRIPTION
This PR makes clearwater-memcached depend on a specific version of memcached. We discussed this and agreed it was a good idea as it prevents a new version of memcached (that is not created by us) with a higher version number from taking precedence over our version. 

Tested by running `sudo clearwater-upgrade` and checking everything upgraded correctly. 