### PR TITLE
[Reviewer: Andy] Only allow the socket factory to connect to a single specified host

### DIFF
--- a/clearwater-socket-factory.md
+++ b/clearwater-socket-factory.md
@@ -4,6 +4,8 @@ The `clearwater-socket-factory` is a service that runs in the system's default n
 
 When traffic separation is enabled on a Clearwater node the default namespace is used for management traffic. This service is used by processes in the signalling namespace (such as Sprout) to obtain connectons to the Metaswitch Service Assurance Server (which lives in the management network).
 
+For security reasons, the socket factory is only allowed to connect to a restricted set of hosts (currently only one is supported). This is to prevent an unprivileged process (such as Sprout) from requesting connections to arbitrary hosts in the default namespace.
+
 ## Interface
 
 `clearwater-socket-factory` runs as a daemon process. Clients communicate with it over a named UNIX socket.
@@ -20,7 +22,9 @@ See the [example client](clearwater-socket-factory/test_client.c) for more detai
 
 ### Error Conditions
 
-If the daemon encounters an error it will indicate this to the client by either:
+If the daemon is asked to connect to a host other than the configured "allowed host" it assumes that the allowed host must have changed. It exists immediately so that it can be restarted and pick up the new value.
+
+If the daemon encounters any other errors it will indicate this to the client by either:
 
 * Closing the connection to client.
 * Sending the client a message containing an invalid (negative) file descriptor.

--- a/clearwater-socket-factory.md
+++ b/clearwater-socket-factory.md
@@ -2,7 +2,7 @@
 
 The `clearwater-socket-factory` is a service that runs in the system's default network namespace. It allows processes running in a different namespace to establish TCP connections from the default namespace.
 
-When traffic separation is enabled on a Clearwater node the default namespace is used for management traffic. This service is used by processes in the signalling namespace (such as Sprout) to obtain connectons to the Metaswitch Service Assurance Server (which lives in the management network).
+When traffic separation is enabled on a Clearwater node the default namespace is used for management traffic. This service is used by processes in the signalling namespace (such as Sprout) to obtain connections to the Metaswitch Service Assurance Server (which lives in the management network).
 
 For security reasons, the socket factory is only allowed to connect to a restricted set of hosts (currently only one is supported). This is to prevent an unprivileged process (such as Sprout) from requesting connections to arbitrary hosts in the default namespace.
 
@@ -22,7 +22,7 @@ See the [example client](clearwater-socket-factory/test_client.c) for more detai
 
 ### Error Conditions
 
-If the daemon is asked to connect to a host other than the configured "allowed host" it assumes that the allowed host must have changed. It exists immediately so that it can be restarted and pick up the new value.
+If the daemon is asked to connect to a host other than the configured "allowed host" it assumes that the allowed host must have changed. It exits immediately so that it can be restarted and pick up the new value.
 
 If the daemon encounters any other errors it will indicate this to the client by either:
 

--- a/debian/clearwater-socket-factory.upstart
+++ b/debian/clearwater-socket-factory.upstart
@@ -10,4 +10,7 @@ stop on runlevel [!2345]
 
 respawn
 
-exec /usr/share/clearwater/bin/clearwater_socket_factory
+script
+  . /etc/clearwater/config
+  /usr/share/clearwater/bin/clearwater_socket_factory "$sas_server"
+end script


### PR DESCRIPTION
Andy, please can you review this PR that prevents the socket factory from creating connections to arbitrary hosts. As it only needs to connect to one host at the moment, I've only enhanced it to take a single host (rather than a list). 

Tested by changing `sas_server` variable on a sprout node, restarting sprout, and checking sprout connected to the new host. 

I have also updated the socket factory readme. No other docs changes are needed. 