### PR TITLE
Reviewer AMC: Scale OPTIONS poll tolerances linearly with target latency

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip
@@ -53,11 +53,28 @@ sip_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
 # Send the SIP message.  The nc line also includes checking the first line of the response says
 # "SIP/2.0 200 OK".
 #
-# The -q option keeps netcat around for 1 second after sending the OPTIONS to
+# The -q option keeps netcat around after sending the OPTIONS to
 # allow the pollee time to send a response before the connection is
 # closed.
+#
+# We can expect OPTIONS response time to scale with target latency (because a
+# high target latency allows worker threads to become tied up with slow
+# requests, thereby delaying OPTIONS responses).  Set the value of -q to be
+# 0.5 secs more than the target latency, rounded up (i.e. 1500000 us more,
+# rounded down).
+#
+# Note that the -w option (the overall timeout) needs to be larger than the -q
+# option - set it to the calculated -q value plus 1.
+wait_time=1
+
+if [ ! -z "$target_latency_us" ]
+then
+  wait_time=$(( $(($target_latency_us + 1500000)) / 1000000 ))
+fi
+
 when_nc_started=$(date --utc  --rfc-3339=ns)
-nc -v -C -w 2 -q 1 $local_ip $port <<EOF 2> /tmp/poll-sip.nc.stderr.$$ | tee /tmp/poll-sip.nc.stdout.$$ | head -1 | egrep -q "^SIP/2.0 (200|503)"
+
+nc -v -C -w $(( $wait_time + 1 )) -q $wait_time $local_ip $port <<EOF 2> /tmp/poll-sip.nc.stderr.$$ | tee /tmp/poll-sip.nc.stdout.$$ | head -1 | egrep -q "^SIP/2.0 (200|503)"
 OPTIONS sip:poll-sip@$sip_ip:$port SIP/2.0
 Via: SIP/2.0/TCP $sip_ip;rport;branch=z9hG4bK-$id
 Max-Forwards: 2


### PR DESCRIPTION
This change makes the SIP poll tolerances (i..e the number of seconds monit will wait for sprout to response to OPTIONs polls before it decides that sprout is unresponsive) scale linearly with the target_latency_us config parameter (if specified).

The need for this change arises when target latency is order of a second or higher.  sprout will not throttle client load until elapsed request time reaches the target latency and, assuming load remains constant, will subsequently reject commands only to keep average latency at this level (with potentially all worker threads locked up in these high letency requests).  While OPTIONs processing does not involve HSS access, an OPTIONS request received on a system in this loaded state will nevertheless be queued up behind other messages that ARE gated on the HSS (or whatever is leading to the high latencies) and so we can expect OPTIONs to take up to target_latency_us microseconds to complete.

Previously the poll-sip script hard coded the response wait time and overall timeout to 1 and 2 seconds respective, so a target latency higher than 1 second has the potential to cause SIP OPTIONS polls to be timed out leading to node termination by monit.

This change scales the response wait time upwards to "target latency plus 0.5 seconds, rounded up" so that a maximally loaded system in this state which is nevertheless processing requests that it has accepted within the target latency, will not be assumed unresponsive by monit and shut down.

Tested by running poll-sip manually against an "nc -l ..." process (accepting the polls, but not responding) to check that timeouts scale upwards as expected with target latency.