### PR TITLE
[Reviewer: Ellie] Fix up migration scripts

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/migration-utils/configlint.py
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/migration-utils/configlint.py
@@ -48,7 +48,6 @@ sprout_hostname
 bono_hostname
 hs_hostname
 hs_provisioning_hostname
-chronos_hostname
 ralf_hostname
 cdf_identity
 xdms_hostname
@@ -74,7 +73,6 @@ enforce_user_phone
 enforce_global_only_lookups
 hs_listen_port
 ralf_listen_port
-alias_list
 default_session_expires
 enum_server
 enum_suffix
@@ -127,11 +125,15 @@ hss_port
 local_ip
 public_ip
 public_hostname
+chronos_hostname
 signaling_namespace
 etcd_cluster
 node_idx
 ralf_diameteridentity
 hs_diameteridentity
+alias_list
+local_site_name
+remote_site_name
 """.split()
 
 for option in settings:

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/migration-utils/migrate_local_config
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/migration-utils/migrate_local_config
@@ -51,4 +51,12 @@ hs_diameteridentity=$hs_diameteridentity
 ralf_diameteridentity=$ralf_diameteridentity
 etcd_cluster=$etcd_cluster
 node_idx=$node_idx
+alias_list=$alias_list
+#chronos_hostname=$chronos_hostname
+
+local_site_name=$local_site_name
+remote_site_name=$local_site_name
 EOF
+
+# Comment out any blank values
+perl -p -i -e 's/^(.*=)$/#$1/' /etc/clearwater/local_config

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/migration-utils/switch_to_migrated_config
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/migration-utils/switch_to_migrated_config
@@ -48,7 +48,7 @@ backup=/etc/clearwater/config.`date +%Y%m%d%H%M%S%N`.migration_backup
 cp /etc/clearwater/config $backup
 echo "Old config backed up to $backup"
 cat <<EOF > /etc/clearwater/config
-. /etc/clearwater/shared_config
+[ -f /etc/clearwater/shared_config ] && . /etc/clearwater/shared_config
 . /etc/clearwater/local_config
 [ -f /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
 EOF


### PR DESCRIPTION
This:
* moves alias_list into local config
* adds the local/remote site names to local config
* comments out any blank entries in local config (so defaulting local_site_name still works)
* doesn't migrate chronos_hostname (as the default is always right) but leaves the old value commented out
* only uses shared_config if it exists (@bossmc)