### PR TITLE
[Reviewer: Alex] etcd diagnostics

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -59,7 +59,7 @@ MIN_IDLE_CPU_FOR_GATHER=40
 # signaling network namespace for multi-interface configurations.
 [ -z "$signaling_dns_server" ] || namespace_dig_server="@$signaling_dns_server"
 
-$management_local_ip=${management_local_ip:-$local_ip}
+management_local_ip=${management_local_ip:-$local_ip}
 
 log()
 {
@@ -404,8 +404,8 @@ get_etcd_info()
 {
   clearwater-etcdctl member list > $CURRENT_DUMP_DIR/etcd_member_list.txt
   clearwater-etcdctl cluster-health > $CURRENT_DUMP_DIR/etcd_cluster_health.txt
-  curl "http://$local_management_ip:4000/v2/keys/clearwater?consistent=true&recursive=true&sorted=false" > $CURRENT_DUMP_DIR/etcd_state.txt
-  curl "http://$local_management_ip:4000/v2/keys/clearwater?recursive=true&sorted=false" > $CURRENT_DUMP_DIR/etcd_state_no_consistency.txt
+  curl "http://$management_local_ip:4000/v2/keys/clearwater?consistent=true&recursive=true&sorted=false" > $CURRENT_DUMP_DIR/etcd_state.txt
+  curl "http://$management_local_ip:4000/v2/keys/clearwater?recursive=true&sorted=false" > $CURRENT_DUMP_DIR/etcd_state_no_consistency.txt
 }
 
 get_cluster_manager_info()

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -59,6 +59,7 @@ MIN_IDLE_CPU_FOR_GATHER=40
 # signaling network namespace for multi-interface configurations.
 [ -z "$signaling_dns_server" ] || namespace_dig_server="@$signaling_dns_server"
 
+$management_local_ip=${management_local_ip:-$local_ip}
 
 log()
 {
@@ -398,6 +399,24 @@ get_mysql_info()
   echo "show databases" | mysql > $CURRENT_DUMP_DIR/mysql_show_databases.txt
 }
 
+# Get information about the etcd cluster.
+get_etcd_info()
+{
+  clearwater-etcdctl member list > $CURRENT_DUMP_DIR/etcd_member_list.txt
+  clearwater-etcdctl cluster-health > $CURRENT_DUMP_DIR/etcd_cluster_health.txt
+  curl "http://$local_management_ip:4000/v2/keys/clearwater?consistent=true&recursive=true&sorted=false" > $CURRENT_DUMP_DIR/etcd_state.txt
+  curl "http://$local_management_ip:4000/v2/keys/clearwater?recursive=true&sorted=false" > $CURRENT_DUMP_DIR/etcd_state_no_consistency.txt
+}
+
+get_cluster_manager_info()
+{
+  /usr/share/clearwater/clearwater-cluster-manager/scripts/check_cluster_health > $CURRENT_DUMP_DIR/etcd_datatore_clusters_health.txt
+}
+
+get_config_manager_info()
+{
+  /usr/share/clearwater/clearwater-config-manager/scripts/check_config_sync > $CURRENT_DUMP_DIR/etcd_config_sync.txt
+}
 
 # Get information about the memcached database.
 get_memcached_info()
@@ -581,6 +600,21 @@ do
   if cw_component_installed sprout ralf
   then
     get_memcached_info
+  fi
+
+  if cw_component_installed clearwater-etcd
+  then
+    get_etcd_info
+  fi
+
+  if cw_component_installed clearwater-cluster-manager
+  then
+    get_cluster_manager_info
+  fi
+
+  if cw_component_installed clearwater-config-manager
+  then
+    get_config_manager_info
   fi
 
   # Gather component specific diags for all installed components.


### PR DESCRIPTION
Adds appropriate diags to clearwater-diags-monitor. Tested live:

```
$ head 20150521211731Z.ec2-54-90-232-39.gather_diags.temp/etcd_*
==> 20150521211731Z.ec2-54-90-232-39.gather_diags.temp/etcd_cluster_health.txt <==
cluster is healthy
member 12f0b9b6edc54780 is unhealthy
member 47064dfe798b77c4 is healthy
member 4d54105549ec3008 is healthy
member 5560d38d82aff414 is healthy
member 678eb7d71ca4a00b is healthy
member 7107133b43a34139 is healthy
member 82577902f771bc49 is healthy
member 86b40cbc7583f1c4 is healthy

==> 20150521211731Z.ec2-54-90-232-39.gather_diags.temp/etcd_datatore_clusters_health.txt <==
Describing sprout memcached cluster in site single_site:
  Local node is in this cluster
  Cluster is healthy and stable
    10.101.154.144 is in state normal
    10.73.136.148 is in state normal

Describing sprout chronos cluster in site single_site:
  Local node is in this cluster
  Cluster is healthy and stable
    10.101.154.144 is in state normal

==> 20150521211731Z.ec2-54-90-232-39.gather_diags.temp/etcd_member_list.txt <==
12f0b9b6edc54780: name= peerURLs=http://10.139.63.96:2380 clientURLs=
47064dfe798b77c4: name=10-101-148-50 peerURLs=http://10.101.148.50:2380 clientURLs=http://10.101.148.50:4000
4d54105549ec3008: name=10-73-136-148 peerURLs=http://10.73.136.148:2380 clientURLs=http://10.73.136.148:4000
5560d38d82aff414: name=10-101-154-144 peerURLs=http://10.101.154.144:2380 clientURLs=http://10.101.154.144:4000
678eb7d71ca4a00b: name=10-71-140-24 peerURLs=http://10.71.140.24:2380 clientURLs=http://10.71.140.24:4000
7107133b43a34139: name=10-137-89-66 peerURLs=http://10.137.89.66:2380 clientURLs=http://10.137.89.66:4000
82577902f771bc49: name=10-139-68-227 peerURLs=http://10.139.68.227:2380 clientURLs=http://10.139.68.227:4000
86b40cbc7583f1c4: name=10-139-23-91 peerURLs=http://10.139.23.91:2380 clientURLs=http://10.139.23.91:4000

==> 20150521211731Z.ec2-54-90-232-39.gather_diags.temp/etcd_state.txt <==
{"action":"get","node":{"key":"/clearwater","dir":true,"nodes":[{"key":"/clearwater/single_site","dir":true,"nodes":[{"key":"/clearwater/single_site/sprout","dir":true,"nodes":[{"key":"/clearwater/single_site/sprout/clustering","dir":true,"nodes":[{"key":"/clearwater/single_site/sprout/clustering/memcached","value":"{\"10.101.154.144\": \"normal\", \"10.73.136.148\": \"normal\"}","modifiedIndex":45,"createdIndex":14},{"key":"/clearwater/single_site/sprout/clustering/chronos","value":"{\"10.101.154.144\": \"normal\", \"10.73.136.148\": \"normal\"}","modifiedIndex":66,"createdIndex":13}],"modifiedIndex":13,"createdIndex":13}],"modifiedIndex":13,"createdIndex":13}],"modifiedIndex":13,"createdIndex":13}],"modifiedIndex":13,"createdIndex":13}}

==> 20150521211731Z.ec2-54-90-232-39.gather_diags.temp/etcd_state_no_consistency.txt <==
{"action":"get","node":{"key":"/clearwater","dir":true,"nodes":[{"key":"/clearwater/single_site","dir":true,"nodes":[{"key":"/clearwater/single_site/sprout","dir":true,"nodes":[{"key":"/clearwater/single_site/sprout/clustering","dir":true,"nodes":[{"key":"/clearwater/single_site/sprout/clustering/chronos","value":"{\"10.101.154.144\": \"normal\", \"10.73.136.148\": \"normal\"}","modifiedIndex":66,"createdIndex":13},{"key":"/clearwater/single_site/sprout/clustering/memcached","value":"{\"10.101.154.144\": \"normal\", \"10.73.136.148\": \"normal\"}","modifiedIndex":45,"createdIndex":14}],"modifiedIndex":13,"createdIndex":13}],"modifiedIndex":13,"createdIndex":13}],"modifiedIndex":13,"createdIndex":13}],"modifiedIndex":13,"createdIndex":13}}
```