### PR TITLE
Reviewer Ellie - clearwater-diags-monitor fixes for etcd work

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -49,7 +49,7 @@ ONE_GB_IN_KB=1000000
 # Required idle CPU for triggering gathering diagnostics
 MIN_IDLE_CPU_FOR_GATHER=40
 
-. /etc/clearwater/config
+. /etc/clearwater/config || exit
 
 # Setup prefix to use when running commands that need to execute within
 # the signaling network namespace for multi-interface configurations. 

--- a/debian/control
+++ b/debian/control
@@ -45,7 +45,7 @@ Description: SNMP service for Clearwater CPU, RAM and I/O statistics
 
 Package: clearwater-diags-monitor
 Architecture: all
-Depends: inotify-tools, realpath, sysstat
+Depends: inotify-tools, realpath, sysstat, clearwater-infrastructure
 Description: Diagnostics monitor and bundler for all Clearwater servers
 
 Package: clearwater-socket-factory


### PR DESCRIPTION
Clearwater diags monitor was starting before /etc/clearwater/config was made by clearwater-infrastructure.  Fixed in two ways, one to make diags monitor depend on infra and the other to make diags monitor exit if it can't load the config (it will be restarted by monit).

Tested on a live system.