### PR TITLE
[Reviewer: Matt] Add in an all-in-one install script

### DIFF
--- a/clearwater-infrastructure/usr/bin/clearwater-aio-install
+++ b/clearwater-infrastructure/usr/bin/clearwater-aio-install
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This installs the Clearwater packages onto an AIO node. It sets up which
+# repo to pull the packages from, and creates numbers on Ellis. This is 
+# used by the OVF install, AIO install through Chef, and the AMI creation
+if [[ $EUID -ne 0 ]]
+then
+  echo "You must run this script with root permissions"
+  exit 1
+fi
+
+if [ $# -ne 2 ]
+then
+  echo "Usage: clearwater-aio-install [repo] [auto_config_package] [number_start] [number_count]"
+  exit 1
+fi
+
+repo=$1
+auto_package=$2
+number_start=$3
+number_count=$4
+
+# Set up the repo
+echo deb \$repo binary/ > /etc/apt/sources.list.d/clearwater.list
+curl -L http://repo.cw-ngv.com/repo_key | sudo apt-key add -
+apt-get update
+
+# Install the clearwater packages
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y --force-yes clearwater-cassandra $auto_package
+apt-get install -y --force-yes ellis bono restund sprout homer homestead homestead-prov
+
+# Create numbers on Ellis
+export PATH=/usr/share/clearwater/ellis/env/bin:$PATH
+python /usr/share/clearwater/ellis/src/metaswitch/ellis/tools/create_numbers.py --start $number_start --count $number_count

--- a/clearwater-infrastructure/usr/bin/clearwater-aio-install
+++ b/clearwater-infrastructure/usr/bin/clearwater-aio-install
@@ -41,7 +41,7 @@ then
   exit 1
 fi
 
-if [ $# -ne 2 ]
+if [ $# -ne 4 ]
 then
   echo "Usage: clearwater-aio-install [repo] [auto_config_package] [number_start] [number_count]"
   exit 1

--- a/debian/clearwater-auto-config-aws.init.d
+++ b/debian/clearwater-auto-config-aws.init.d
@@ -49,24 +49,24 @@
 do_auto_config()
 {
   mkdir -p /etc/clearwater
-  config=/etc/clearwater/config
-  # wget -qO - http://169.254.169.254/latest/user-data | sed 's/'`echo "\015"`'//g' >>$config
+ 
+  local_config=/etc/clearwater/local_config
+  shared_config=/etc/clearwater/shared_config
+
   local_ip=$(wget -qO - http://169.254.169.254/latest/meta-data/local-ipv4)
   public_ip=$(wget -qO - http://169.254.169.254/latest/meta-data/public-ipv4)
   public_hostname=$(wget -qO - http://169.254.169.254/latest/meta-data/public-hostname)
 
   sed -e 's/^local_ip=.*$/local_ip='$local_ip'/g
           s/^public_ip=.*$/public_ip='$public_ip'/g
-          s/^public_hostname=.*$/public_hostname='$public_hostname'/g
-          s/^sprout_hostname=.*$/sprout_hostname='$public_hostname'/g
+          s/^public_hostname=.*$/public_hostname='$public_hostname'/g' -i $local_config
+
+  sed -e 's/^sprout_hostname=.*$/sprout_hostname='$public_hostname'/g
           s/^xdms_hostname=.*$/xdms_hostname='$public_hostname':7888/g
           s/^hs_hostname=.*$/hs_hostname='$public_hostname':8888/g
-          s/^chronos_hostname=.*$/chronos_hostname='$local_ip':7253/g
           s/^hs_provisioning_hostname=.*$/hs_provisioning_hostname='$public_hostname':8889/g
-          s/^upstream_hostname=.*$/upstream_hostname='$public_hostname'/g' < /etc/clearwater/config > /etc/clearwater/config2
+          s/^upstream_hostname=.*$/upstream_hostname='$public_hostname'/g' -i $shared_config
 
-  rm /etc/clearwater/config
-  mv /etc/clearwater/config2 /etc/clearwater/config
   # Sprout will replace the cluster-settings file with something appropriate when it starts
   rm /etc/clearwater/cluster_settings
 }

--- a/debian/clearwater-auto-config-aws.install
+++ b/debian/clearwater-auto-config-aws.install
@@ -1,0 +1,1 @@
+clearwater-auto-config/* /

--- a/scripts/clearwater-aio-install.sh
+++ b/scripts/clearwater-aio-install.sh
@@ -41,16 +41,20 @@ then
   exit 1
 fi
 
-if [ $# -ne 4 ]
+if [ $# -lt 1 || $# -gt 4 ]
 then
-  echo "Usage: clearwater-aio-install [repo] [auto_config_package] [number_start] [number_count]"
+  echo "Usage: clearwater-aio-install [auto_config_package] <repo> <number_start> <number_count>"
   exit 1
 fi
 
-repo=$1
-auto_package=$2
+auto_package=$1
+repo=$2 
 number_start=$3
 number_count=$4
+
+[ -n "$repo" ] || repo=http://repo.cw-ngv.com/stable
+[ -n "$number_start" ] || number_start=6505550000
+[ -n "$number_count" ] || number_count=1000
 
 # Set up the repo
 echo deb \$repo binary/ > /etc/apt/sources.list.d/clearwater.list
@@ -59,7 +63,7 @@ apt-get update
 
 # Install the clearwater packages
 export DEBIAN_FRONTEND=noninteractive
-apt-get install -y --force-yes clearwater-cassandra $auto_package
+apt-get install -y --force-yes $auto_package clearwater-cassandra
 apt-get install -y --force-yes ellis bono restund sprout homer homestead homestead-prov
 
 # Create numbers on Ellis

--- a/scripts/clearwater-aio-install.sh
+++ b/scripts/clearwater-aio-install.sh
@@ -41,7 +41,7 @@ then
   exit 1
 fi
 
-if [ $# -lt 1 || $# -gt 4 ]
+if [[ $# -lt 1 || $# -gt 4 ]]
 then
   echo "Usage: clearwater-aio-install [auto_config_package] <repo> <number_start> <number_count>"
   exit 1
@@ -57,7 +57,7 @@ number_count=$4
 [ -n "$number_count" ] || number_count=1000
 
 # Set up the repo
-echo deb \$repo binary/ > /etc/apt/sources.list.d/clearwater.list
+echo deb $repo binary/ > /etc/apt/sources.list.d/clearwater.list
 curl -L http://repo.cw-ngv.com/repo_key | sudo apt-key add -
 apt-get update
 


### PR DESCRIPTION
Matt, can you review this change to add a script for an AIO install. I've taken it from the OVF install, and I'll move both Chef and clearwater-vm-images to use this. 

I've also fixed up the aws/docker auto config packages to use local/shared config. 

Part of the fix for https://github.com/Metaswitch/chef/issues/192