### PR TITLE
[Reviewer: Matt] Bail out if snmpd.conf is absent

### DIFF
--- a/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd
+++ b/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd
@@ -33,6 +33,13 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 #
 
+# Do nothing if snmpd.conf is absent (e.g. mid-install)
+
+if [ ! -e /etc/snmp/snmpd.conf ]
+then
+    exit 0
+fi
+
 #
 # Add informsink entries to /etc/snmp/snmpd.conf based upon the snmp_ip
 # Clearwater config setting.


### PR DESCRIPTION
Fixes #186.

Testing:
Before:
```
$ bash ./clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd
./clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd: line 44: /etc/clearwater/config: No such file or directory
sed: can't read /etc/snmp/snmpd.conf: No such file or directory
sed: can't read /etc/snmp/snmpd.conf: No such file or directory
diff: /etc/snmp/snmpd.conf: No such file or directory
mv: cannot move `/tmp/snmpd.conf.2617' to `/etc/snmp/snmpd.conf': No such file or directory
initctl: Rejected send message, 1 matched rules; type="method_call", sender=":1.12" (uid=1000 pid=2622 comm="initctl emit --no-wait snmpd-config-change ") interface="com.ubuntu.Upstart0_6" member="EmitEvent" error name="(unset)" requested_reply="0" destination="com.ubuntu.Upstart" (uid=0 pid=1 comm="/sbin/init ")
mkdir: cannot create directory `/var/run/clearwater': Permission denied
chmod: cannot access `/var/run/clearwater/stats': No such file or directory
```

after this change, it does nothing:

```
$ bash ./clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd
$
```

after this change, after touching /etc/snmp/snmpd.conf, it carries on:

```
$ bash ./clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd
./clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd: line 51: /etc/clearwater/config: No such file or directory
mkdir: cannot create directory `/var/run/clearwater': Permission denied
chmod: cannot access `/var/run/clearwater/stats': No such file or directory
```