### PR TITLE
[Reviewer: Matt] Don't stop memcached unnecessarily

### DIFF
--- a/debian/clearwater-memcached.postinst
+++ b/debian/clearwater-memcached.postinst
@@ -55,7 +55,6 @@ case "$1" in
     configure)
         install /usr/share/clearwater/infrastructure/conf/memcached_11211.monit /etc/monit/conf.d/
         /usr/share/clearwater/infrastructure/scripts/memcached
-        /etc/init.d/memcached stop 11211 || /bin/true
         [ ! -x /etc/init.d/clearwater-secure-connections ] || /etc/init.d/clearwater-secure-connections reload
         reload clearwater-monit || /bin/true
     ;;


### PR DESCRIPTION
Fixes #175. This is safe because /usr/share/clearwater/infrastructure/scripts/memcached stops memcached if it changes something (https://github.com/Metaswitch/clearwater-infrastructure/blob/master/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached#L104).