### PR TITLE
[Reviewer: Matt] Allow AgentX helpers, and remove Sprout/Bono plugins as these are now…

### DIFF
--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -192,6 +192,7 @@ linkUpDownNotifications  yes
                                            #  Listen for network connections (from localhost)
                                            #    rather than the default named socket /var/agentx/master
 #agentXSocket    tcp:localhost:705
+agentXPerms 777
 
 rocommunity clearwater 0.0.0.0/0 -V clearwater
 rocommunity6 clearwater ::/0 -V clearwater
@@ -220,8 +221,6 @@ view clearwater included .1.2.826.0.1.1578918.9
 # Project Clearwater informsink start
 # Project Clearwater informsink end
 
-dlmod sprout_handler /usr/lib/clearwater/sprout_handler.so
-dlmod bono_handler /usr/lib/clearwater/bono_handler.so
 dlmod homestead_handler /usr/lib/clearwater/homestead_handler.so
 dlmod alarm_handler /usr/lib/clearwater/alarm_handler.so
 dlmod cdiv_handler /usr/lib/clearwater/cdiv_handler.so


### PR DESCRIPTION
… AgentX-served

It's a bit of a shame that we have to make the AgentX socket world-writeable - in the long term we should set up a 'clearwater' group, have common infrastructure owned by that group, and start all processes in that group. But for now, we don't expect untrusted users to have access to the system anyway.