### PR TITLE
[Reviewer: Andy] Report exceptions to syslog properly

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/alarms.py
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/alarms.py
@@ -77,7 +77,6 @@ def sendrequest(request):
 
       context.destroy(100)
 
-  except:
-    e = sys.exc_info()[0]
-    syslog.syslog(syslog.LOG_ERR, e)
+  except Exception as e:
+    syslog.syslog(syslog.LOG_ERR, str(e))
 


### PR DESCRIPTION
Same kind of problem as yesterday. I've tested by running the following in the Python interpreter:

```
>>> try:
...   int("as")
... except Exception as e:
...   import syslog
...   syslog.syslog(syslog.LOG_ERR, str(e))

```