### PR TITLE
Reviewer RKD: Auto config packages use their own bracket_ipv6_address.py scripts

### DIFF
--- a/debian/clearwater-auto-config-docker.init.d
+++ b/debian/clearwater-auto-config-docker.init.d
@@ -62,7 +62,7 @@ do_auto_config()
   fi
 
   # Add square brackets around the address iff it is an IPv6 address
-  bracketed_ip=$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $ip)
+  bracketed_ip=$(python /usr/share/clearwater/clearwater-auto-config-docker/bin/bracket_ipv6_address.py $ip)
 
   sed -e 's/^local_ip=.*$/local_ip='$ip'/g
           s/^public_ip=.*$/public_ip='$ip'/g

--- a/debian/clearwater-auto-config-docker.install
+++ b/debian/clearwater-auto-config-docker.install
@@ -1,1 +1,2 @@
 clearwater-auto-config/* /
+clearwater-infrastructure/usr/share/clearwater/bin/bracket_ipv6_address.py /usr/share/clearwater/clearwater-auto-config-docker/bin/bracket_ipv6_address.py

--- a/debian/clearwater-auto-config-generic.init.d
+++ b/debian/clearwater-auto-config-generic.init.d
@@ -66,7 +66,7 @@ do_auto_config()
           s/^public_hostname=.*$/public_hostname='$ip'/g' -i $local_config
 
   # Add square brackets around the address iff it is an IPv6 address
-  bracketed_ip=$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $ip)
+  bracketed_ip=$(python /usr/share/clearwater/clearwater-auto-config-generic/bin/bracket_ipv6_address.py $ip)
 
   sed -e 's/^sprout_hostname=.*$/sprout_hostname='$ip'/g
           s/^xdms_hostname=.*$/xdms_hostname='$bracketed_ip':7888/g

--- a/debian/clearwater-auto-config-generic.install
+++ b/debian/clearwater-auto-config-generic.install
@@ -1,1 +1,2 @@
 clearwater-auto-config/* /
+clearwater-infrastructure/usr/share/clearwater/bin/bracket_ipv6_address.py /usr/share/clearwater/clearwater-auto-config-generic/bin/bracket_ipv6_address.py


### PR DESCRIPTION
Hi Rob,

Can you review your own suggested fix to https://github.com/Metaswitch/clearwater-infrastructure/issues/82, where clearwater-auto-config-generic (and presumably clearwater-auto-config-docker) have a circular dependency with clearwater-infrastructure.

I haven't done any testing of this - do you think it's worth it, and if so, what is the easiest way to test this?

This fixes https://github.com/Metaswitch/clearwater-infrastructure/issues/82.

Thanks,
Graeme