### PR TITLE
[Reviewer: Alex] Reduce Cassandra memory usage on AIO nodes

### DIFF
--- a/scripts/clearwater-aio-install.sh
+++ b/scripts/clearwater-aio-install.sh
@@ -63,9 +63,17 @@ echo deb $repo binary/ > /etc/apt/sources.list.d/clearwater.list
 curl -L http://repo.cw-ngv.com/repo_key | sudo apt-key add -
 apt-get update
 
-# Install the clearwater packages
+# Install the initial clearwater packages
 export DEBIAN_FRONTEND=noninteractive
 apt-get install -y --force-yes $auto_package clearwater-cassandra
+
+# Patch Cassandra's configuration to reduce its memory usage, and stop it to
+# make monit restart it
+sed -e 's/#MAX_HEAP_SIZE=".*"/MAX_HEAP_SIZE="512M"/g' -i /etc/cassandra/cassandra-env.sh
+sed -e 's/#HEAP_NEWSIZE=".*"/HEAP_NEWSIZE="128M"/g' -i /etc/cassandra/cassandra-env.sh
+service cassandra stop
+
+# Install the remaining clearwater packages
 apt-get install -y --force-yes ellis bono restund sprout homer homestead homestead-prov
 
 # Create numbers on Ellis


### PR DESCRIPTION
Alex,

Please can you review this fix to make AIO nodes work on Ubuntu 14.04.  It seems like the memory requirements on 14.04 are higher, and so the OOM killer is hot more frequently.  To avoid this, my fix is to reduce Cassandra's memory requirements from half of all memory to approximately a third.  Given that we don't expect AIO nodes to run under much load, this should be fine.

I've tested live.

Matt