### PR TITLE
[Reviewer: Ellie] Fix up permissions on /var/agentx directory

### DIFF
--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -188,11 +188,9 @@ linkUpDownNotifications  yes
 #  AgentX Sub-agents
 #
                                            #  Run as an AgentX master agent
- master          agentx
-                                           #  Listen for network connections (from localhost)
-                                           #    rather than the default named socket /var/agentx/master
-#agentXSocket    tcp:localhost:705
-agentXPerms 777
+master          agentx
+agentXSocket /var/agentx/master
+agentXPerms 777 777 root snmp
 
 rocommunity clearwater 0.0.0.0/0 -V clearwater
 rocommunity6 clearwater ::/0 -V clearwater

--- a/debian/clearwater-snmpd.postinst
+++ b/debian/clearwater-snmpd.postinst
@@ -61,6 +61,11 @@ case "$1" in
         mkdir -p /var/run/clearwater/stats
         chmod -R o+wr /var/run/clearwater/stats
 
+        # SNMPd doesn't reset the /var/agentx directory permissions automatically after a config
+        # change (http://net-snmp-coders.narkive.com/bCaMJSZF/user-permissions-and-agentx#post4) so
+        # do that manually
+        chmod 777 /var/agentx
+
         # Update snmpd.conf based upon the content of Clearwater config
         /usr/share/clearwater/infrastructure/scripts/snmpd 
         service snmpd restart || true


### PR DESCRIPTION
I spotted that SNMP stats weren't working on staging - this is because /var/agentx defaults to permissions 0700, and SNMPD doesn't change the permissions even if you subsequently change the config. This adds a chmod to fix that up. (I think this is a 14.04 change in behaviour, though maybe I'm just really bad at testing).

Tested live (by upgrading clearwater-snmpd on my Bono and confirming that it worked).