### PR TITLE
[Reviewer: Matt] Remove fragile SNMP alarm parsing code

### DIFF
--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -216,9 +216,6 @@ view clearwater included .1.3.6.1.2.1.121.1.1.1
 # MIBs defined by Project Clearwater
 view clearwater included .1.2.826.0.1.1578918
 
-# Project Clearwater informsink start
-# Project Clearwater informsink end
-
 dlmod homestead_handler /usr/lib/clearwater/homestead_handler.so
 dlmod cdiv_handler /usr/lib/clearwater/cdiv_handler.so
 dlmod memento_handler /usr/lib/clearwater/memento_handler.so

--- a/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd
+++ b/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd
@@ -33,53 +33,5 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 #
 
-#
-# Add informsink entries to /etc/snmp/snmpd.conf based upon the snmp_ip
-# Clearwater config setting.
-#
-
-START_MARK="# Project Clearwater informsink start"
-END_MARK="# Project Clearwater informsink end"
-
-. /etc/clearwater/config
-
-# Create a temporary copy of snmpd.conf with contents up to the start of
-# Clearwater informsink definitions.
-
-sed '1,/'"$START_MARK"'/ !d' /etc/snmp/snmpd.conf > /tmp/snmpd.conf.$$
-
-# Add informslink definitions to end of temporary copy based upon comma
-# seperated list of hosts defined by snmp_ip.
-
-IFS=',' read -a SNMP_HOSTS <<< "$snmp_ip"
-
-for HOST in "${SNMP_HOSTS[@]}";
-do
-  echo "informsink $HOST clearwater" >> /tmp/snmpd.conf.$$
-done
-
-# Copy remainder of snmpd.conf from the end of informsink definitions to
-# the temporary copy.
-
-sed '/'"$END_MARK"'/,$ !d' /etc/snmp/snmpd.conf >> /tmp/snmpd.conf.$$
-
-# Compare original with the temporary copy. If it has changed replace
-# the original and trigger an snmpd restart to pick up the changes,
-# otherwise remove the temporary copy.
-
-diff /etc/snmp/snmpd.conf /tmp/snmpd.conf.$$ > /dev/null
-
-if [ $? -ne 0 ];
-then
-  mv /tmp/snmpd.conf.$$ /etc/snmp/snmpd.conf
-
-  service snmpd restart 
-else
-  rm /tmp/snmpd.conf.$$
-fi
-
-#
-# Create the folder to store the statistics UNIX domain sockets.
-#
 mkdir -p /var/run/clearwater/stats
 chmod -R o+wr /var/run/clearwater/stats


### PR DESCRIPTION
Now that alarms live in a standalone process (https://github.com/Metaswitch/clearwater-snmp-handlers/blob/master/debian/clearwater-snmp-alarm-agent.init.d#L106), we don't need to update snmpd.conf with the alarm destinations - they're passed into the standalone process directly.

Fixes #186, supersedes #196.