### PR TITLE
[Reviewer: Andy] Move /etc/default/memcached responsibility into clearwater-memcached

### DIFF
--- a/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
@@ -50,3 +50,4 @@ sed -e 's/^-l .*$/-l '$listen_address'/g'\
     -e 's/^# *-v *$/-v/g'\
     -e 's/^\(# *\|\)-c.*$/-c 4096/g' </etc/memcached.conf >/etc/memcached_11211.conf
 
+echo "START_PREFIX=/usr/share/clearwater/bin/run-in-signaling-namespace" > /etc/default/memcached

--- a/debian/clearwater-memcached.prerm
+++ b/debian/clearwater-memcached.prerm
@@ -53,6 +53,7 @@ set -e
 case "$1" in
     remove|upgrade|deconfigure)
         rm -f /etc/monit/conf.d/memcached_11211.monit
+        rm -f /etc/default/memcached
         reload clearwater-monit &> /dev/null || true
     ;;
 

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Description: Common infrastructure for all Clearwater servers
 
 Package: clearwater-memcached
 Architecture: all
-Depends: clearwater-infrastructure, memcached (= 1.6.00-0clearwater0.4)
+Depends: clearwater-infrastructure, memcached (= 1.6.00-0clearwater0.5)
 Conflicts: clearwater-infinispan
 Suggests: clearwater-secure-connections
 Description: memcached configured for Clearwater


### PR DESCRIPTION
Corresponding fix to https://github.com/Metaswitch/memcached/pull/13.

Note that I'm echoing into /etc/default/memcached rather than creating `clearwater-memcached/etc/default/memcached` - this is because I'm nervous about file conflicts (if clearwater-memcached and a pre-upgrade memcached are both briefly trying to manage /etc/default/memcached). I'm not quite sure what the upgrade ordering is, so I might be being over-cautious, but it can't hurt.