### PR TITLE
[Reviewer: Andy] Add clearwater-infrastructure dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,6 +44,7 @@ Description: Diagnostics monitor and bundler for all Clearwater servers
 
 Package: clearwater-socket-factory
 Architecture: all
+Depends: clearwater-infrastructure
 Description: Enables other processes to establish connections using a different network namespace
 
 # NB clearwater-auto-config packages do NOT depend on infrastructure, as they


### PR DESCRIPTION
Add clearwater-infrastructure as a dependency. 
I've spun up a clearwater-base box through chef and checked nothing obviously broke

Fixes #260 
