### PR TITLE
Add sleep to clearwater-socket-factory.upstart

### DIFF
--- a/debian/clearwater-socket-factory.upstart
+++ b/debian/clearwater-socket-factory.upstart
@@ -38,6 +38,9 @@ script
                  $signaling_allowed_hosts"
   }
 
+  # Sleep for 2 seconds, to avoid upstart respawning socket-factory too quickly
+  sleep 2
+  
   . /etc/clearwater/config
   get_daemon_args
   /usr/share/clearwater/bin/clearwater_socket_factory $DAEMON_ARGS


### PR DESCRIPTION
Adding a short sleep to avoid hitting race condition between socket-factory and shared_config being applied.
Should prevent upstart spamming respawn, and then giving up before the race condition closes.

Fixes #266 