### PR TITLE
[Reviewer: Alex] Switch to lz4 rather than gzip for less CPU impact when gathering diags

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -530,8 +530,8 @@ do
   BASE_DUMP=$(date --utc "+%Y%m%d%H%M%S")Z.$(hostname).$cause
   CURRENT_DUMP=$BASE_DUMP.temp
   CURRENT_DUMP_DIR=$DUMPS_DIR/$CURRENT_DUMP
-  CURRENT_DUMP_ARCHIVE=$CURRENT_DUMP_DIR.tar.gz
-  FINAL_DUMP_ARCHIVE=$DUMPS_DIR/$BASE_DUMP.tar.gz
+  CURRENT_DUMP_ARCHIVE=$CURRENT_DUMP_DIR.tar.lz4
+  FINAL_DUMP_ARCHIVE=$DUMPS_DIR/$BASE_DUMP.tar.lz4
   CURRENT_CW_COMPONENTS=$(clearwater_packages)
 
   # Create a new dump directory.
@@ -694,7 +694,7 @@ do
   do
     core_file=${trigger_files_arr[$jj]}
     jj=$(( $jj + 1 ))
-    gzip $CURRENT_DUMP_DIR/$core_file
+    lz4 $CURRENT_DUMP_DIR/$core_file $CURRENT_DUMP_DIR/$core_file.lz4 && rm $CURRENT_DUMP_DIR/$core_file
   done
   #
   # Diags have been collected.  Time to zip up the diags bundle.
@@ -708,8 +708,10 @@ do
   # -p  Preserve file permissions.
   # -c  Create an archive.
   # -z  Zip the archive.
-  # -f  Name of the archive.
-  (cd $DUMPS_DIR; tar -pcz -f $CURRENT_DUMP_ARCHIVE $CURRENT_DUMP)
+  # -f  Output file (stdout)
+  #
+  # We then pipe the tar output to lz4, to compress it quickly (much less CPU impact than gzip).
+  (cd $DUMPS_DIR; tar -pc -f - $CURRENT_DUMP | lz4 - $CURRENT_DUMP_ARCHIVE)
   log "Diagnostic archive $CURRENT_DUMP_ARCHIVE created"
   rm -rf "$CURRENT_DUMP_DIR"
 

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Description: SNMP service for Clearwater CPU, RAM and I/O statistics
 
 Package: clearwater-diags-monitor
 Architecture: all
-Depends: inotify-tools, realpath, sysstat, clearwater-infrastructure
+Depends: inotify-tools, realpath, sysstat, clearwater-infrastructure, liblz4-tool
 Description: Diagnostics monitor and bundler for all Clearwater servers
 
 Package: clearwater-socket-factory


### PR DESCRIPTION
As discussed yesterday, lz4 uses a lot less CPU, so this change should mimimise the amount of CPU we spend compressing diags after a crash, and allow us to handle appropriate load more quickly.

I've tested by:
- compressing the same 2GB core file with gzip and lz4 - gzip compressed it to 22MB (1%) in 18 seconds, lz4 to 45MB (2%) in 1 second. I think that's a very sensible tradeoff.
- checking that I got /var/clearwater-diags-monitor/dumps/20151119093352Z.ec2-54-86-26-64.sprout.tar.lz4 after a crash
- uncompressing that and checking that the .tar file contained a core.sprout.1447925602.lz4 file