### PR TITLE
[Reviewer: Andy] Make the sysDescr OID visible to the 'clearwater' community

### DIFF
--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -195,7 +195,8 @@ agentXPerms 777 777 root snmp
 rocommunity clearwater 0.0.0.0/0 -V clearwater
 rocommunity6 clearwater ::/0 -V clearwater
 
-# SNMP uptime
+# SNMP system OIDs
+view clearwater included .1.3.6.1.2.1.1.1.0
 view clearwater included .1.3.6.1.2.1.1.3.0
 
 # UCD-SNMP-MIB memory stats


### PR DESCRIPTION
This avoids the problem in https://github.com/Metaswitch/clearwater-infrastructure/issues/261. Unlike https://github.com/Metaswitch/clearwater-net-snmp/pull/2, it's a workaround rather than a fix - but if you think that PR's ramifications are too risky/too poorly understood, this is a workable alternative.