### PR TITLE
Reviewer AMC: Ignore custom mandatory AVPs from Metaswitch

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/generic_create_diameterconf
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/generic_create_diameterconf
@@ -173,4 +173,8 @@ LoadExtension = "$fd_dir/dict_dcca_3gpp.fdx";
 # Uncomment to allow ignoring the Destination-Host AVP on incoming requests
 $dh_commenter LoadExtension = "$fd_dir/rt_change_dh.fdx";
 
+# If we receive an AVP that is marked as mandatory from one of these vendors,
+# we ignore the mandatory flag.
+UntrustedAVPVendors = 19444;
+
 EOF


### PR DESCRIPTION
Accompanying change for https://github.com/Metaswitch/freeDiameter/pull/27/.

I'm not intending to abstract it any further, but if we ever wanted to it would presumably be trivial to do so.