### PR TITLE
[Reviewer: Matt] Ensure that local and public hostnames always resolve

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/hostname
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/hostname
@@ -37,13 +37,20 @@
 # Read our config file.
 . /etc/clearwater/config
 
+grep -v ' #+clearwater-infrastructure$' /etc/hosts > /tmp/hosts.$$
+
 # Check if the public hostname is actually an IPv4 address or an IPv6 address.
 if echo $public_hostname | egrep -v -q -e '^[0-9.]+$' -e '^[0-9A-Fa-f:]+$'
 then
   # If not, get the first (most-specific) part, and set that as the server's internal hostname.
-  echo $public_hostname | sed -e 's/\..*//g' >/etc/hostname
-  hostname $(cat /etc/hostname)
-  grep -v ' #+clearwater-infrastructure$' /etc/hosts >/tmp/hosts.$$
-  mv /tmp/hosts.$$ /etc/hosts
-  echo $local_ip $(cat /etc/hostname) '#+clearwater-infrastructure' >>/etc/hosts
+  echo $public_hostname | sed -e 's/\..*//g' > /etc/hostname
+
+  # Also, ensure that the public hostname is resolvable
+  echo $local_ip $public_hostname '#+clearwater-infrastructure' >> /tmp/hosts.$$
 fi
+
+# Ensure that the local hostname is resolvable (regardless of whether it was us that set it or not)
+hostname $(cat /etc/hostname)
+echo $local_ip $(cat /etc/hostname) '#+clearwater-infrastructure' >> /tmp/hosts.$$
+
+mv /tmp/hosts.$$ /etc/hosts

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/hostname
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/hostname
@@ -42,11 +42,8 @@ grep -v ' #+clearwater-infrastructure$' /etc/hosts > /tmp/hosts.$$
 # Check if the public hostname is actually an IPv4 address or an IPv6 address.
 if echo $public_hostname | egrep -v -q -e '^[0-9.]+$' -e '^[0-9A-Fa-f:]+$'
 then
-  # If not, get the first (most-specific) part, and set that as the server's internal hostname.
-  echo $public_hostname | sed -e 's/\..*//g' > /etc/hostname
-
-  # Also, ensure that the public hostname is resolvable
-  echo $local_ip $public_hostname '#+clearwater-infrastructure' >> /tmp/hosts.$$
+  # If not, set that as the server's internal hostname.
+  echo $public_hostname > /etc/hostname
 fi
 
 # Ensure that the local hostname is resolvable (regardless of whether it was us that set it or not)


### PR DESCRIPTION
This fixes #67 (with the approach discussed in that issue).

I've tested by editing my Chef cookbook to make public_hostname in local_config always be `hghdsghsaghjdsgdhjjw.gfshjgsdfxdsgjsagsaj`, spinning up a deployment, and checking my Sprout ad Homestead nodes (specifically checking Sprout, Cassandra and sudo as the three troublesome commands described in #67):

```
[homestead-1]ubuntu@hghdsghsaghjdsgdhjjw:~$ sudo ls
[homestead-1]ubuntu@hghdsghsaghjdsgdhjjw:~$ hostname
hghdsghsaghjdsgdhjjw
[homestead-1]ubuntu@hghdsghsaghjdsgdhjjw:~$ ps aux | grep cassandra
cassand+ 24326  2.6 66.8 1726196 1368572 ?     SLl  22:00   0:12 /usr/lib/jvm/java-7-openjdk-amd64//bin/java -ea -javaagent:/usr/share/cassandra/lib/jamm-0.2.5.jar -XX:+CMSClassUnloadingEnabled -XX:+UseThreadPriorities -XX:ThreadPriorityPolicy=42 -Xms1000M -Xmx1000M -Xmn100M -XX:+HeapDumpOnOutOfMemoryError -Xss256k -XX:StringTableSize=1000003 -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=1 -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+UseTLAB -XX:+CMSParallelInitialMarkEnabled -XX:+CMSEdenChunksRecordAlways -XX:+UseCondCardMark -Djava.net.preferIPv4Stack=true -Dcassandra.jmx.local.port=7199 -XX:+DisableExplicitGC -ea -javaagent:/usr/share/cassandra/lib/jamm-0.2.5.jar -XX:+CMSClassUnloadingEnabled -XX:+UseThreadPriorities -XX:ThreadPriorityPolicy=42 -Xms1000M -Xmx1000M -Xmn100M -XX:+HeapDumpOnOutOfMemoryError -Xss256k -XX:StringTableSize=1000003 -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=1 -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+UseTLAB -XX:+CMSParallelInitialMarkEnabled -XX:+CMSEdenChunksRecordAlways -XX:+UseCondCardMark -Djava.net.preferIPv4Stack=true -Dcassandra.jmx.local.port=7199 -XX:+DisableExplicitGC -Dlog4j.configuration=log4j-server.properties -Dlog4j.defaultInitOverride=true -Dcassandra-pidfile=/var/run/cassandra/cassandra.pid -cp /etc/cassandra:/usr/share/cassandra/lib/antlr-3.2.jar:/usr/share/cassandra/lib/commons-cli-1.1.jar:/usr/share/cassandra/lib/commons-codec-1.2.jar:/usr/share/cassandra/lib/commons-lang3-3.1.jar:/usr/share/cassandra/lib/compress-lzf-0.8.4.jar:/usr/share/cassandra/lib/concurrentlinkedhashmap-lru-1.3.jar:/usr/share/cassandra/lib/disruptor-3.0.1.jar:/usr/share/cassandra/lib/guava-15.0.jar:/usr/share/cassandra/lib/high-scale-lib-1.1.2.jar:/usr/share/cassandra/lib/jackson-core-asl-1.9.2.jar:/usr/share/cassandra/lib/jackson-mapper-asl-1.9.2.jar:/usr/share/cassandra/lib/jamm-0.2.5.jar:/usr/share/cassandra/lib/jbcrypt-0.3m.jar:/usr/share/cassandra/lib/jline-1.0.jar:/usr/share/cassandra/lib/json-simple-1.1.jar:/usr/share/cassandra/lib/libthrift-0.9.1.jar:/usr/share/cassandra/lib/log4j-1.2.16.jar:/usr/share/cassandra/lib/lz4-1.2.0.jar:/usr/share/cassandra/lib/metrics-core-2.2.0.jar:/usr/share/cassandra/lib/netty-3.6.6.Final.jar:/usr/share/cassandra/lib/reporter-config-2.1.0.jar:/usr/share/cassandra/lib/servlet-api-2.5-20081211.jar:/usr/share/cassandra/lib/slf4j-api-1.7.2.jar:/usr/share/cassandra/lib/slf4j-log4j12-1.7.2.jar:/usr/share/cassandra/lib/snakeyaml-1.11.jar:/usr/share/cassandra/lib/snappy-java-1.0.5.jar:/usr/share/cassandra/lib/snaptree-0.1.jar:/usr/share/cassandra/lib/super-csv-2.1.0.jar:/usr/share/cassandra/lib/thrift-server-0.3.7.jar:/usr/share/cassandra/apache-cassandra-2.0.14.jar:/usr/share/cassandra/apache-cassandra-thrift-2.0.14.jar:/usr/share/cassandra/apache-cassandra.jar:/usr/share/cassandra/stress.jar:/usr/share/java/jna.jar: -XX:HeapDumpPath=/var/lib/cassandra/java_1456437653.hprof -XX:ErrorFile=/var/lib/cassandra/hs_err_1456437653.log org.apache.cassandra.service.CassandraDaemon
root     27415  0.0  0.0      0     0 ?        Zs   22:08   0:00 [poll_cassandra.] <defunct>
ubuntu   27435  0.0  0.0  10460   936 pts/3    S+   22:08   0:00 grep --color=auto cassandra
[homestead-1]ubuntu@hghdsghsaghjdsgdhjjw:~$ . /etc/clearwater/config
[homestead-1]ubuntu@hghdsghsaghjdsgdhjjw:~$ echo $public_hostname
hghdsghsaghjdsgdhjjw.gfshjgsdfxdsgjsagsaj


[sprout-1]ubuntu@hghdsghsaghjdsgdhjjw:~$ . /etc/clearwater/config
[sprout-1]ubuntu@hghdsghsaghjdsgdhjjw:~$ echo $public_hostname
hghdsghsaghjdsgdhjjw.gfshjgsdfxdsgjsagsaj
[sprout-1]ubuntu@hghdsghsaghjdsgdhjjw:~$ hostname
hghdsghsaghjdsgdhjjw
[sprout-1]ubuntu@hghdsghsaghjdsgdhjjw:~$ ps aux | grep "/usr/share/clearwater/bin/sprout"
sprout   15438  0.1  2.9 1708292 60248 ?       Sl   21:58   0:01 /usr/share/clearwater/bin/sprout --domain=rkd2.cw-ngv.com --localhost=10.0.78.51 --realm=rkd2.cw-ngv.com --memstore=/etc/clearwater/cluster_settings --remote-memstore=/etc/clearwater/remote_cluster_settings --hss=hs.rkd2.cw-ngv.com:8888 --chronos=127.0.0.1:7253 --xdms=homer.rkd2.cw-ngv.com:7888 --sas=sas.cw-ngv.com,sprout@hghdsghsaghjdsgdhjjw.gfshjgsdfxdsgjsagsaj --dns-server=127.0.0.1 --pjsip-threads=1 --worker-threads=50 --http-threads=50 --record-routing-model=pcscf --default-session-expires=600 --init-token-rate=250 --authentication --http-address=10.0.78.51 --http-port=9888 --analytics=/var/log/sprout --log-file=/var/log/sprout --log-level=2 --pidfile=/var/run/sprout/sprout.pid --alias=52.91.161.93,hghdsghsaghjdsgdhjjw.gfshjgsdfxdsgjsagsaj,sprout-icscf.rkd2.cw-ngv.com,sprout-icscf-site1.rkd2.cw-ngv.com,sprout-icscf-site2.rkd2.cw-ngv.com,sprout-site1.rkd2.cw-ngv.com,sprout-site2.rkd2.cw-ngv.com --scscf=5054 --scscf-uri=sip:sprout.rkd2.cw-ngv.com;transport=tcp --icscf=5052
ubuntu   19283  0.0  0.0  10596   940 pts/4    S+   22:10   0:00 grep --color=auto /usr/share/clearwater/bin/sprout
```