### PR TITLE
[Reviewer: Ellie] Uptime failure

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/check-uptime
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/check-uptime
@@ -41,17 +41,21 @@ REQUIRED_UPTIME=30
 # Bail out and return non-zero if anything goes wrong.
 set -e
 
-# The command-line argument is the pidfile for the process.
-[ $# = 1 ] || { echo "Usage: check-uptime <pidfile>" >&2 ; exit 2 ; }
+# The first command-line argument is the pidfile for the process.
+# The second and third arguments are passed through to the script issue_alarm,
+# for it to use to clear the process-not-ready alarm.
+[ $# = 3 ] || { echo "Usage: check-uptime <pidfile> <issuer> <alarm>" >&2 ; exit 2 ; }
 pidfile=$1
+issuer=$2
+alarm=$3
 
 # It's expected that there might not be a pidfile.
 pid=$( cat $pidfile 2>/dev/null)
 
 value=$( ps -p $pid -o etimes= 2>/dev/null) || { echo "No process matching value from pidfile: $pid" >&2 ; exit 1 ; }
 if [ "$value" -ge "$REQUIRED_UPTIME" ]; then
+  "/usr/share/clearwater/bin/issue_alarm.py $issuer $alarm"
   exit 0
 else
   exit 1
 fi
-echo "Did not exit"

--- a/clearwater-memcached/usr/share/clearwater/infrastructure/conf/memcached_11211.monit
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/conf/memcached_11211.monit
@@ -46,11 +46,11 @@ check process memcached_process with pidfile "/var/run/memcached_11211.pid"
   if memory > 80% for 6 cycles then restart
 
 # Clear any alarms if the process has been running long enough.
-check program memcached_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/memcached_11211.pid"
+check program memcached_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/memcached_11211.pid monit 3500.1"
   group memcached
   depends on memcached_process
   every 3 cycles
-  if status = 0 then exec "/usr/share/clearwater/bin/issue_alarm.py monit 3500.1"
+  if status != 0 then alert
 
 # Check the memcached process is listening. This depends on the memcached process (and so won't run
 # unless the memcached process is running)


### PR DESCRIPTION
This fixes around issue #293. Rather than allowing monit to exec the issue_alarm script (which triggers it to mark the script as failed), get our check-uptime script to clear the alarm.

I've marked all of the other repos that I've fixed this in as no-reviewer as it's all the same stuff.

I've checked that this fixes the issue by spinning up a deployment and running `watch sudo monit summary`.
