### PR TITLE
[Reviewer: Adam] Install etcd on all-in-one nodes

### DIFF
--- a/clearwater-auto-config/etc/clearwater/local_config
+++ b/clearwater-auto-config/etc/clearwater/local_config
@@ -2,3 +2,4 @@
 local_ip=
 public_ip=
 public_hostname=
+etcd_cluster=

--- a/debian/clearwater-auto-config-aws.init.d
+++ b/debian/clearwater-auto-config-aws.init.d
@@ -59,6 +59,7 @@ do_auto_config()
 
   sed -e 's/^local_ip=.*$/local_ip='$local_ip'/g
           s/^public_ip=.*$/public_ip='$public_ip'/g
+          s/^etcd_cluster=.*$/etcd_cluster='$local_ip'/g
           s/^public_hostname=.*$/public_hostname='$public_hostname'/g' -i $local_config
 
   sed -e 's/^sprout_hostname=.*$/sprout_hostname='$public_hostname'/g

--- a/debian/clearwater-auto-config-generic.init.d
+++ b/debian/clearwater-auto-config-generic.init.d
@@ -63,6 +63,7 @@ do_auto_config()
 
   sed -e 's/^local_ip=.*$/local_ip='$ip'/g
           s/^public_ip=.*$/public_ip='$ip'/g
+          s/^etcd_cluster=.*$/etcd_cluster='$ip'/g
           s/^public_hostname=.*$/public_hostname='$ip'/g' -i $local_config
 
   # Add square brackets around the address iff it is an IPv6 address

--- a/scripts/clearwater-aio-install.sh
+++ b/scripts/clearwater-aio-install.sh
@@ -65,7 +65,7 @@ apt-get update
 
 # Install the initial clearwater packages
 export DEBIAN_FRONTEND=noninteractive
-apt-get install -y --force-yes $auto_package clearwater-etcd clearwater-cassandra < /dev/null
+apt-get install -y --force-yes $auto_package clearwater-management clearwater-cassandra < /dev/null
 
 # Patch Cassandra's configuration to reduce its memory usage, and stop it to
 # make monit restart it

--- a/scripts/clearwater-aio-install.sh
+++ b/scripts/clearwater-aio-install.sh
@@ -65,7 +65,7 @@ apt-get update
 
 # Install the initial clearwater packages
 export DEBIAN_FRONTEND=noninteractive
-apt-get install -y --force-yes $auto_package clearwater-cassandra < /dev/null
+apt-get install -y --force-yes $auto_package clearwater-etcd clearwater-cassandra < /dev/null
 
 # Patch Cassandra's configuration to reduce its memory usage, and stop it to
 # make monit restart it


### PR DESCRIPTION
This installs the clearwater-management package (config/cluster/queue manager) on all-in-one nodes. I've tested live (by spinning up an AWS AIO node and running some live tests).