### PR TITLE
[Reviewer: Ellie] Cope with Monit restrictions

### DIFF
--- a/clearwater-memcached/usr/share/clearwater/infrastructure/conf/memcached_11211.monit
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/conf/memcached_11211.monit
@@ -46,7 +46,7 @@ check process memcached_process with pidfile "/var/run/memcached_11211.pid"
   if memory > 80% for 6 cycles then restart
 
 # Clear any alarms if the process has been running long enough.
-check program memcached_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/memcached_11211.pid monit 3500.1"
+check program memcached_uptime with path /usr/share/clearwater/infrastructure/scripts/check-memcached-uptime
   group memcached
   depends on memcached_process
   every 3 cycles

--- a/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/check-memcached-uptime
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/check-memcached-uptime
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# @file check-uptime
+# @file check-memcached-uptime
 #
 # Project Clearwater - IMS in the Cloud
 # Copyright (C) 2016  Metaswitch Networks Ltd
@@ -34,28 +34,7 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-# Checks that a process has been running for at least REQUIRED_UPTIME
-# seconds. Returns 0 if it has. Returns a non-zero value if it has not.
-REQUIRED_UPTIME=30
-
-# Bail out and return non-zero if anything goes wrong.
-set -e
-
-# The first command-line argument is the pidfile for the process.
-# The second and third arguments are passed through to the script issue_alarm,
-# for it to use to clear the process-not-ready alarm.
-[ $# = 3 ] || { echo "Usage: check-uptime <pidfile> <issuer> <alarm>" >&2 ; exit 2 ; }
-pidfile=$1
-issuer=$2
-alarm=$3
-
-# It's expected that there might not be a pidfile.
-pid=$( cat $pidfile 2>/dev/null)
-
-value=$( ps -p $pid -o etimes= 2>/dev/null) || { echo "No process matching value from pidfile: $pid" >&2 ; exit 1 ; }
-if [ "$value" -ge "$REQUIRED_UPTIME" ]; then
-  /usr/share/clearwater/bin/issue_alarm.py "$issuer" "$alarm"
-  exit 0
-else
-  exit 1
-fi
+# Monit 5.8.1 does not support passing arguments to check program scripts.
+# check-uptime provides common uptime-checking code. This wrapper script
+# uses it, and can be called with no arguments.
+/usr/share/clearwater/bin/check-uptime /var/run/memcached_11211.pid monit 3500.1


### PR DESCRIPTION
Monit can't pass arguments to check-program scripts in its current version.

This should fix the "failed" flickering issue.

I've raised a bunch of other similar pull requests - no need to review them all.