### PR TITLE
Reviewer EM: Restart dnsmasq

### DIFF
--- a/debian/clearwater-auto-config-aws.init.d
+++ b/debian/clearwater-auto-config-aws.init.d
@@ -75,6 +75,8 @@ do_auto_config()
   grep -v ' #+scscf.aio$' /etc/hosts > /tmp/hosts.$$
   echo $local_ip scscf.$public_hostname '#+scscf.aio'>> /tmp/hosts.$$
   mv /tmp/hosts.$$ /etc/hosts
+
+  service dnsmasq restart
 }
 
 case "$1" in

--- a/debian/clearwater-auto-config-docker.init.d
+++ b/debian/clearwater-auto-config-docker.init.d
@@ -128,6 +128,8 @@ do_auto_config()
   grep -v ' #+scscf.aio$' /etc/hosts > /tmp/hosts.$$
   echo $ip scscf.$sprout_hostname '#+scscf.aio'>> /tmp/hosts.$$
   mv /tmp/hosts.$$ /etc/hosts
+
+  service dnsmasq restart
 }
 
 case "$1" in

--- a/debian/clearwater-auto-config-generic.init.d
+++ b/debian/clearwater-auto-config-generic.init.d
@@ -82,6 +82,8 @@ do_auto_config()
   grep -v ' #+scscf.aio$' /etc/hosts > /tmp/hosts.$$
   echo $ip scscf.$ip '#+scscf.aio'>> /tmp/hosts.$$
   mv /tmp/hosts.$$ /etc/hosts
+
+  service dnsmasq restart
 }
 
 case "$1" in


### PR DESCRIPTION
We saw an issue where the new entries in /etc/hosts weren't being picked up on AIO nodes. This should fix that issue.

I'm testing by spinning up an AIO node with this change right now.