### PR TITLE
[Reviewer: Matt] Fix package version dependencies, and start snmp on install

### DIFF
--- a/rpm/clearwater-memcached.spec
+++ b/rpm/clearwater-memcached.spec
@@ -2,8 +2,7 @@ Name:           clearwater-memcached
 Summary:        memcached configured for Clearwater
 BuildArch:      noarch
 BuildRequires:  python2-devel python-virtualenv
-Requires:       redhat-lsb-core clearwater-infrastructure memcached
-#Requires:       redhat-lsb-core clearwater-infrastructure memcached=1.6.00-0clearwater0.5
+Requires:       redhat-lsb-core clearwater-infrastructure memcached = 1.6.00-0clearwater0.5
 #Suggests:       clearwater-secure-connections
 
 %include %{rootdir}/build-infra/cw-rpm.spec.inc

--- a/rpm/clearwater-snmpd.spec
+++ b/rpm/clearwater-snmpd.spec
@@ -2,7 +2,7 @@ Name:           clearwater-snmpd
 Summary:        SNMP service for Clearwater CPU, RAM and I/O statistics
 BuildArch:      noarch
 BuildRequires:  python2-devel python-virtualenv
-Requires:       redhat-lsb-core  net-snmp = 1:5.7.2-24.el7.centos.1.clearwater1 clearwater-infrastructure
+Requires:       redhat-lsb-core net-snmp = 1:5.7.2-24.el7.centos.1.clearwater1 clearwater-infrastructure
 
 %include %{rootdir}/build-infra/cw-rpm.spec.inc
 
@@ -25,5 +25,7 @@ systemctl start snmpd
 if [ "$1" == 0 ] ; then
   /usr/share/clearwater/infrastructure/install/clearwater-snmpd.prerm
 fi
+systemctl stop snmpd
+systemctl disable snmpd
 
 %files -f clearwater-snmpd.files

--- a/rpm/clearwater-snmpd.spec
+++ b/rpm/clearwater-snmpd.spec
@@ -2,8 +2,7 @@ Name:           clearwater-snmpd
 Summary:        SNMP service for Clearwater CPU, RAM and I/O statistics
 BuildArch:      noarch
 BuildRequires:  python2-devel python-virtualenv
-Requires:       redhat-lsb-core net-snmp net-snmp-libs clearwater-infrastructure
-#Requires:       redhat-lsb-core net-snmp>=5.7.2~dfsg-clearwater4 net-snmp-libs>=5.7.2~dfsg-clearwater4 clearwater-infrastructure
+Requires:       redhat-lsb-core  net-snmp = 1:5.7.2-24.el7.centos.1.clearwater1 clearwater-infrastructure
 
 %include %{rootdir}/build-infra/cw-rpm.spec.inc
 
@@ -18,6 +17,8 @@ build_files_list > clearwater-snmpd.files
 
 %post
 /usr/share/clearwater/infrastructure/install/clearwater-snmpd.postinst
+systemctl enable snmpd
+systemctl start snmpd
 
 %preun
 # Uninstall, not upgrade


### PR DESCRIPTION
Small changes to do the following for Centos builds:

- Fix package dependencies for clearwater-snmp
- Fix version formatting for dependencies in clearwater-memcached (the only other build that depends on a specific package version)
- Start snmp on installation of clearwater-snmpd