### PR TITLE
[Reviewer: Adam] Get clearwater-radius-auth working under CentOS

### DIFF
--- a/clearwater-radius-auth/etc/libnss-ato.conf
+++ b/clearwater-radius-auth/etc/libnss-ato.conf
@@ -1,1 +1,1 @@
-ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
+radius_authenticated_user:x:1000:1000:radius_authenticated_user:/tmp:/bin/bash

--- a/clearwater-radius-auth/usr/share/clearwater/infrastructure/install/clearwater-radius-auth.postinst
+++ b/clearwater-radius-auth/usr/share/clearwater/infrastructure/install/clearwater-radius-auth.postinst
@@ -34,11 +34,8 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-. /usr/share/clearwater/infrastructure/install/common
-
 # Adds 'ato' after the password and shadow entries in nsswitch.conf.
 # This sets NSS to check the libnss_ato component for the user if they are not found locally.
 sed -i "s/\(\(passwd\|shadow\).*\)/\1 ato/" /etc/nsswitch.conf
 # Adds a sufficient check for RADIUS authentication before the standard UNIX authentication.
-sed -i "s/\(\#\sStandard\sUn\*x\sauthentication\..*\)/# +clearwater-radius-auth\nauth sufficient pam_radius_auth.so\n# -clearwater-radius-auth\n\1/" /etc/pam.d/sshd
-sed -i "s/\(\#\sStandard\sUn\*x\sauthentication\..*\)/# +clearwater-radius-auth\nauth sufficient pam_radius_auth.so\n# -clearwater-radius-auth\n\1/" /etc/pam.d/login
+sed -i "3i# +clearwater-radius-auth\nauth sufficient pam_radius_auth.so\n# -clearwater-radius-auth\n" /etc/pam.d/sshd

--- a/clearwater-radius-auth/usr/share/clearwater/infrastructure/install/clearwater-radius-auth.prerm
+++ b/clearwater-radius-auth/usr/share/clearwater/infrastructure/install/clearwater-radius-auth.prerm
@@ -34,7 +34,5 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-. /usr/share/clearwater/infrastructure/install/common
-
 sed -i "s/ ato//" /etc/nsswitch.conf
 sed -i "/+clearwater-radius-auth/,/-clearwater-radius-auth/d" /etc/pam.d/sshd

--- a/rpm/clearwater-radius-auth.spec
+++ b/rpm/clearwater-radius-auth.spec
@@ -2,7 +2,7 @@ Name:           clearwater-radius-auth
 Summary:        Package enabling RADIUS authentication on Clearwater nodes
 BuildArch:      noarch
 BuildRequires:  python2-devel python-virtualenv
-Requires:       redhat-lsb-core libpam-radius-auth libnss-ato
+Requires:       redhat-lsb-core pam_radius libnss-ato
 
 %include %{rootdir}/build-infra/cw-rpm.spec.inc
 
@@ -16,7 +16,10 @@ install_to_buildroot < %{rootdir}/debian/clearwater-radius-auth.install
 build_files_list > clearwater-radius-auth.files
 
 %post
-/usr/share/clearwater/infrastructure/install/clearwater-radius-auth.postinst
+# Initial install, not upgrade
+if [ "$1" == 0 ] ; then
+  /usr/share/clearwater/infrastructure/install/clearwater-radius-auth.postinst
+fi
 
 %preun
 # Uninstall, not upgrade


### PR DESCRIPTION
Tested by:

* installing it and checking I could SSH in with my RADIUS credentials, and that I became the right user
* checking that I couldn't log in with an incorrect username or password
* upgrading and checking that I didn't get multiple entries in /etc/pam.d/sshd or /etc/nsswitch.conf
* uninstalling and checking that the entries added were removed

All that was on CentOS - I'll also test the first bullet (is it basically working) on Ubuntu.