### PR TITLE
[Reviewer: Adam] Actually run postinst script on install

### DIFF
--- a/rpm/clearwater-radius-auth.spec
+++ b/rpm/clearwater-radius-auth.spec
@@ -17,7 +17,7 @@ build_files_list > clearwater-radius-auth.files
 
 %post
 # Initial install, not upgrade
-if [ "$1" == 0 ] ; then
+if [ "$1" == 1 ] ; then
   /usr/share/clearwater/infrastructure/install/clearwater-radius-auth.postinst
 fi
 


### PR DESCRIPTION
In trying to stop the postinst script from running on package upgrade, I managed to stop it from ever running. This fixes that.

(Source - http://www.ibm.com/developerworks/library/l-rpm2/, which says 'Similarly, the arguments to a %post are 1 and 2 for a new installation and upgrade, respectively.')