### PR TITLE
[Reviewer: Ellie] Don't attempt to edit /etc/bash.bashrc if it does not exist

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/install/clearwater-infrastructure.postinst
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/install/clearwater-infrastructure.postinst
@@ -57,8 +57,11 @@ EOF
   fi
 }
 
-add_section /etc/bash.bashrc clearwater-infrastructure /etc/bash.bashrc.clearwater
 add_config_shim
+
+if [ -f /etc/bash.bashrc ]; then
+  add_section /etc/bash.bashrc clearwater-infrastructure /etc/bash.bashrc.clearwater
+fi
 
 for HOME_DIR in $(find /home -mindepth 1 -maxdepth 1 -type d) ; do
   if [ -e $HOME_DIR/.bashrc ]; then


### PR DESCRIPTION
The file `/etc/bash.bashrc` does not exist on centos so we shouldn't try to edit it. 

This caused the script to bail out early which causes various carnage (`/etc/clearwater/config` file not added, certain eggs not installed, etc). 

Tested by installing clearwater-infratructure on a vanilla centos box, checking the out put was clean and that `/etc/clearwater/config` was created. 