### PR TITLE
[Reviewer: Matt] Migrate init.d scripts to use init-utils.bash where appropriate

### DIFF
--- a/debian/clearwater-diags-monitor.init.d
+++ b/debian/clearwater-diags-monitor.init.d
@@ -65,11 +65,12 @@ DAEMON=/usr/share/clearwater/bin/clearwater_diags_monitor
 # Define LSB log_* functions.
 # Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
 . /lib/lsb/init-functions
-type log_daemon_msg >/dev/null 2>&1 || log_daemon_msg() { log_success_msg $@ ; }
-type log_end_msg >/dev/null 2>&1 || log_end_msg() { true ; }
 
 # Include /etc/init.d/functions if available.
 [ -r /etc/init.d/functions ] && . /etc/init.d/functions
+
+# Include the clearwater init helpers.
+. /usr/share/clearwater/utils/init-utils.bash
 
 #
 # Function that starts the daemon/service
@@ -87,7 +88,7 @@ do_start()
         #   0 if daemon has been started
         #   1 if daemon was already running
         #   2 if daemon could not be started
-        if which start-stop-daemon > /dev/null 2>&1 ; then
+        if have_start_stop_daemon; then
                 start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
                         || return 1
                 start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --nicelevel 19 --iosched idle --exec $DAEMON \
@@ -111,14 +112,11 @@ do_stop()
         #   1 if daemon was already stopped
         #   2 if daemon could not be stopped
         #   other if a failure occurred
-        if which start-stop-daemon > /dev/null 2>&1 ; then
+        if have_start_stop_daemon; then
                 start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
         else
-                [ ! -f $PIDFILE ] || killproc -p $(cat $PIDFILE) -d 30
-                rm -f $PIDFILE
-                pkill -f $DAEMON
+                stop_daemon $PIDFILE TERM 30
         fi
-        return $?
 }
 
 #

--- a/debian/clearwater-infrastructure.init.d
+++ b/debian/clearwater-infrastructure.init.d
@@ -60,8 +60,9 @@ SCRIPTNAME=/etc/init.d/$NAME
 # Define LSB log_* functions.
 # Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
 . /lib/lsb/init-functions
-type log_daemon_msg >/dev/null 2>&1 || log_daemon_msg() { log_success_msg $@ ; }
-type log_end_msg >/dev/null 2>&1 || log_end_msg() { true ; }
+
+# Include the clearwater init helpers.
+. /usr/share/clearwater/utils/init-utils.bash
 
 #
 # Function that starts the daemon/service

--- a/debian/clearwater-secure-connections.init.d
+++ b/debian/clearwater-secure-connections.init.d
@@ -63,8 +63,9 @@ SCRIPTNAME=/etc/init.d/$NAME
 # Define LSB log_* functions.
 # Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
 . /lib/lsb/init-functions
-type log_daemon_msg >/dev/null 2>&1 || log_daemon_msg() { log_success_msg $@ ; }
-type log_end_msg >/dev/null 2>&1 || log_end_msg() { true ; }
+
+# Include the clearwater init helpers.
+. /usr/share/clearwater/utils/init-utils.bash
 
 #
 # Function that starts the daemon/service


### PR DESCRIPTION
Matt, please could you review this PR to make some scripts in clearwater-infrastructure use the new `init-utils.bash` script I added recently.

I've tested this by installing clearwater-infrastructure and clearwater-diags-monitor on a node. Then:

* `sudo service clearwater-infrastructure restart` ran cleanly. 
* `sudo service clearwater-diags-monitor start` ran cleanly and caused the diags monitor to start.
* `sudo service clearwater-diags-monitor stop` ran cleanly and caused the diags monitor to stop.

I've not tested clearwater-secure-connections as the change is identical to the change for clearwater infrastructure. 