### PR TITLE
[No Reviewer] Fix spec to pull in net-snmp-utils

### DIFF
--- a/rpm/clearwater-snmpd.spec
+++ b/rpm/clearwater-snmpd.spec
@@ -2,7 +2,7 @@ Name:           clearwater-snmpd
 Summary:        SNMP service for Clearwater CPU, RAM and I/O statistics
 BuildArch:      noarch
 BuildRequires:  python2-devel python-virtualenv
-Requires:       redhat-lsb-core net-snmp = 1:5.7.2-24.el7.centos.1.clearwater1 clearwater-infrastructure clearwater-monit
+Requires:       redhat-lsb-core net-snmp = 1:5.7.2-24.el7.centos.1.clearwater1 net-snmp-utils = 1:5.7.2-24.el7.centos.1.clearwater1 clearwater-infrastructure clearwater-monit
 
 %include %{rootdir}/build-infra/cw-rpm.spec.inc
 


### PR DESCRIPTION
Net-snmp-utils was not explicitly required by clearwater-snmpd. 
This meant that installing clearwater-snmpd did not install commands such as `snmpget`.

Tested on a clean centos node, all works fine