### PR TITLE
[Reviewer: Matt] Upgrade all repos starting with the word clearwater.

### DIFF
--- a/clearwater-infrastructure/usr/bin/clearwater-upgrade
+++ b/clearwater-infrastructure/usr/bin/clearwater-upgrade
@@ -1,7 +1,8 @@
 #!/bin/bash
 if which yum > /dev/null 2>&1 ; then
-  sudo yum makecache --disablerepo=* --enablerepo=clearwater &&
-  sudo yum update --disablerepo=* --enablerepo=clearwater "$@"
+  # Upgrade any repos that start with the word clearwater.
+  sudo yum makecache --disablerepo=* --enablerepo=clearwater* &&
+  sudo yum update --disablerepo=* --enablerepo=clearwater* "$@"
 else
   apt-get update -o Dir::Etc::sourcelist="sources.list.d/clearwater.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" &&
   apt-get install "$@" -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew\


### PR DESCRIPTION
Hi Matt, 

Please can you review this PR that enhances `clearwater-upgrade` top upgrade all repos whose name starts with "clearwater" (rather than just the single repo whose name is exactly clearwater). This is useful if you want to serve up code from multiple repos (e.g. from the public repo, and a private repo). 

Tested live. 