### PR TITLE
[Reviewer: Ellie] Update checkpid logic

### DIFF
--- a/debian/clearwater-diags-monitor.init.d
+++ b/debian/clearwater-diags-monitor.init.d
@@ -94,7 +94,7 @@ do_start()
                 start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --nicelevel 19 --iosched idle --exec $DAEMON \
                         || return 2
         else
-                [ ! -f $PIDFILE ] || checkpid $(cat $PIDFILE) || return 1
+                [ ! -f $PIDFILE ] || ! checkpid $(cat $PIDFILE) || return 1
                 ionice -n 3 nice -n 19 daemonize -p $PIDFILE $DAEMON || return 2
         fi
 


### PR DESCRIPTION
Was seeing the behaviour that clearwater-diags-monitor process was not being restarted correctly, as there was a PID file with a process number in, but that number did not correspond to any running process. 
The updated logic below is the fix for this. 

Can you just check this is the right thing here, and i'm not missing something obvious?