### PR TITLE
[Reviewer: Ellie] Add ntp to infrastructure dependencies

### DIFF
--- a/rpm/clearwater-infrastructure.spec
+++ b/rpm/clearwater-infrastructure.spec
@@ -2,7 +2,7 @@ Name:           clearwater-infrastructure
 Summary:        Common infrastructure for all Clearwater servers
 BuildArch:      noarch
 BuildRequires:  python2-devel python-virtualenv zeromq-devel
-Requires:       redhat-lsb-core python zeromq
+Requires:       redhat-lsb-core python zeromq ntp
 
 %include %{rootdir}/build-infra/cw-rpm.spec.inc
 


### PR DESCRIPTION
Simply adds ntp as a dependency in rpm spec file to mirror debian control.

Trying to upgrade a clearwater-infrastructure installation to the new package using `yum update`, on a node that doesn't have ntp already installed, will throw a dependency error. This can be resolved by using `yum install` or just installing ntp before upgrading. 

Tested, and this does correctly install ntp. Tested that monit brings ntp back when killed, and it does. 
This installation does not enable the ntp service in systemctl, but as monit will be in place I do not think this is an issue.