### PR TITLE
[Reviewer: Matt] Allow using a different repo for initial installs and upgrades

### DIFF
--- a/scripts/clearwater-aio-install.sh
+++ b/scripts/clearwater-aio-install.sh
@@ -45,21 +45,23 @@ fi
 
 if [[ $# -lt 1 || $# -gt 4 ]]
 then
-  echo "Usage: clearwater-aio-install [auto_config_package] <repo> <number_start> <number_count>"
+  echo "Usage: clearwater-aio-install [auto_config_package] <install_repo> <updates_repo> <number_start> <number_count>"
   exit 1
 fi
 
 auto_package=$1
-repo=$2
-number_start=$3
-number_count=$4
+install_repo=$2
+updates_repo=$3
+number_start=$4
+number_count=$5
 
-[ -n "$repo" ] || repo=http://repo.cw-ngv.com/stable
+[ -n "$install_repo" ] || install_repo=http://repo.cw-ngv.com/stable
+[ -n "$updates_repo" ] || updates_repo=http://repo.cw-ngv.com/stable
 [ -n "$number_start" ] || number_start=6505550000
 [ -n "$number_count" ] || number_count=1000
 
 # Set up the repo
-echo deb $repo binary/ > /etc/apt/sources.list.d/clearwater.list
+echo deb $install_repo binary/ > /etc/apt/sources.list.d/clearwater.list
 curl -L http://repo.cw-ngv.com/repo_key | sudo apt-key add -
 apt-get update
 
@@ -73,3 +75,6 @@ apt-get install -y --force-yes ellis bono restund sprout homer homestead homeste
 # Create numbers on Ellis
 export PATH=/usr/share/clearwater/ellis/env/bin:$PATH
 python /usr/share/clearwater/ellis/src/metaswitch/ellis/tools/create_numbers.py --start $number_start --count $number_count
+
+# Now switch over to using the repo we expect to get updates from.
+echo deb $updates_repo binary/ > /etc/apt/sources.list.d/clearwater.list


### PR DESCRIPTION
I've been thinking about how to do more testing of the release before actually publishing packages to our stable repo. I think the right approach for the OVA is:

* freeze code
* install the packages from staging
* verify that the OVA works
* set it up so that future updates come from the stable repo

This PR accomplishes that goal by allowing you to specify a different repo to use after the initial install. I'll then make the corresponding changes to https://github.com/Metaswitch/chef/blob/35e37eeacdd55aa2926301b30c3ad09789555e0f/cookbooks/clearwater/recipes/cw_aio.rb#L39 and https://github.com/Metaswitch/clearwater-vm-images/blob/36cf7806c063889cf68cf12b233421bea2bb6d9b/ubuntu-ovf/ubuntu-server.seed#L106 without review.

One thing I wasn't sure on was whether I should add updates_repo as the last argument - this is less neat but more back-compatible (e.g. if there's a caller of this script I've forgotten about).