### PR TITLE
[Reviewer: Rob] Change hostname from cwaio to cw-aio

### DIFF
--- a/debian/clearwater-auto-config-generic.init.d
+++ b/debian/clearwater-auto-config-generic.init.d
@@ -50,7 +50,7 @@ do_auto_config()
 {
   local_config=/etc/clearwater/local_config
   shared_config=/etc/clearwater/shared_config
-  aio_hostname=cwaio
+  aio_hostname=cw-aio
 
   if [ -f /etc/clearwater/force_ipv6 ]
   then


### PR DESCRIPTION
Fixes #363.  Tested live by patching AIO instance and rebooting.