### PR TITLE
[Reviewer: Matt] clearwater-infrastructure and clearwater-socket-factory aren't archit…

### DIFF
--- a/rpm/clearwater-infrastructure.spec
+++ b/rpm/clearwater-infrastructure.spec
@@ -1,6 +1,5 @@
 Name:           clearwater-infrastructure
 Summary:        Common infrastructure for all Clearwater servers
-BuildArch:      noarch
 BuildRequires:  python2-devel python-virtualenv zeromq-devel
 Requires:       redhat-lsb-core python zeromq ntp
 

--- a/rpm/clearwater-socket-factory.spec
+++ b/rpm/clearwater-socket-factory.spec
@@ -1,6 +1,5 @@
 Name:           clearwater-socket-factory
 Summary:        Enables other processes to establish connections using a different network namespace
-BuildArch:      noarch
 BuildRequires:  python2-devel python-virtualenv
 Requires:       redhat-lsb-core clearwater-infrastructure
 


### PR DESCRIPTION
…ecture-independent

I saw that the RPMs were being built as noarch, but the contain binary code - this fixes that.