### PR TITLE
[Reviewer: RKD] Add IPv6 localhost entry to /etc/hosts

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/1hosts
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/1hosts
@@ -41,20 +41,21 @@
 # If the local IP address is an IPv6 address then the system needs a dummy
 # hostname that maps to the address.
 
-# Remove any previous dummy hostname from the hosts file.  Also delete any
-# previous IPv6 localhost entries.
-grep -v ' # maps to local IPv6 address' /etc/hosts | grep -v '::1 localhost' > /tmp/hosts.$$
+# Remove any entries that have been previously added by this script.
+grep -v ' # added by clearwater-infrastructure 1hosts script' /etc/hosts > /tmp/hosts.$$
 
 # Determine whether the local IP address is an IPv6 address.
 if /usr/share/clearwater/bin/is-address-ipv6 $local_ip
 then
   # Generate the ip6.arpa hostname from the IP address.  Add it to the hosts file.
   hostname=$(/usr/share/clearwater/bin/ipv6-to-hostname $local_ip)
-  echo $local_ip $hostname '# maps to local IPv6 address' >> /tmp/hosts.$$
+  echo $local_ip $hostname '# added by clearwater-infrastructure 1hosts script' >> /tmp/hosts.$$
 fi
 
-# Append the IPv6 localhost
-echo '::1 localhost' >> /tmp/hosts.$$
+# Append the IPv6 localhost.  This is to satisfy RFC6761 section 6.3, namely
+# "Users may assume that IPv4 and IPv6 address queries for localhost names
+# will always resolve to the respective IP loopback address."
+echo '::1 localhost # added by clearwater-infrastructure 1hosts script' >> /tmp/hosts.$$
 
 # Compare the new hosts file with the existing one.  If it has changed overwrite
 # the existing file and restart dnsmasq to pick up the changes, otherwise just

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/1hosts
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/1hosts
@@ -41,8 +41,9 @@
 # If the local IP address is an IPv6 address then the system needs a dummy
 # hostname that maps to the address.
 
-# Remove any previous dummy hostname from the hosts file.
-grep -v ' # maps to local IPv6 address' /etc/hosts > /tmp/hosts.$$
+# Remove any previous dummy hostname from the hosts file.  Also delete any
+# previous IPv6 localhost entries.
+grep -v ' # maps to local IPv6 address' /etc/hosts | grep -v '::1 localhost' > /tmp/hosts.$$
 
 # Determine whether the local IP address is an IPv6 address.
 if /usr/share/clearwater/bin/is-address-ipv6 $local_ip
@@ -51,6 +52,9 @@ then
   hostname=$(/usr/share/clearwater/bin/ipv6-to-hostname $local_ip)
   echo $local_ip $hostname '# maps to local IPv6 address' >> /tmp/hosts.$$
 fi
+
+# Append the IPv6 localhost
+echo '::1 localhost' >> /tmp/hosts.$$
 
 # Compare the new hosts file with the existing one.  If it has changed overwrite
 # the existing file and restart dnsmasq to pick up the changes, otherwise just


### PR DESCRIPTION
Add `::1 localhost` to `/etc/hosts` so that we can return a lookup for `localhost` in IPv6 only networks.

This fixes Metaswitch/sprout#1510 and gets us further towards fixing Metaswitch/homestead#13