### PR TITLE
[Reviewer: Graeme] Add Clearwater script directories to the path

### DIFF
--- a/clearwater-infrastructure/etc/bash.bashrc.clearwater
+++ b/clearwater-infrastructure/etc/bash.bashrc.clearwater
@@ -23,3 +23,5 @@ else
     PS1='${debian_chroot:+($debian_chroot)}['$type$node_idx']\u@\h:\w\$ '
 fi
 unset type node_idx
+
+PATH=$PATH:/usr/share/clearwater/bin:/usr/share/clearwater/clearwater-cluster-manager/scripts:/usr/share/clearwater/clearwater-queue-manager/scripts:/usr/share/clearwater/clearwater-config-manager/scripts


### PR DESCRIPTION
I've checked that I can run just `run-in-signaling-namespace ifconfig` and get output (and in fact, `run-i<TAB>` completes).

Stuff that runs under sudo is a bit different because sudo resets the path, so `sudo check_config_sync` doesn't work, but

```
$ sudo bash
# check_config_sync
```

does.