### PR TITLE
[Reviewer: Ellie] Use $HOME to determine the dump directory

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
@@ -35,7 +35,7 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 DIAGS_LOCATION=/var/clearwater-diags-monitor/dumps/
-DIAGS_END_LOCATION=/home/clearwater/ftp/dumps/
+DIAGS_END_LOCATION=${HOME}/ftp/dumps/
 
 if [ $# -ne 0 ]
 then


### PR DESCRIPTION
This is better than hardcoding either 'clearwater' or 'ubuntu' (or indeed 'centos' or 'defcraft').