### PR TITLE
[Reviewer: Ellie] Add script to check for root permissions

### DIFF
--- a/clearwater-infrastructure/usr/bin/clearwater-upgrade
+++ b/clearwater-infrastructure/usr/bin/clearwater-upgrade
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+. /usr/share/clearwater/utils/check-root-permissions
+
 if which yum > /dev/null 2>&1 ; then
   # Upgrade any repos that start with the word clearwater.
   sudo yum makecache --disablerepo=* --enablerepo=clearwater* &&

--- a/clearwater-infrastructure/usr/share/clearwater/utils/check-root-permissions
+++ b/clearwater-infrastructure/usr/share/clearwater/utils/check-root-permissions
@@ -3,7 +3,7 @@
 # @file check-root-permissions
 #
 # Project Clearwater - IMS in the Cloud
-# Copyright (C) 2015  Metaswitch Networks Ltd
+# Copyright (C) 2016  Metaswitch Networks Ltd
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -36,7 +36,7 @@
 
 # Usage:
 #
-# To use this script, add the following a bash file:
+# To use this script, add the following to a bash file:
 #
 # . /usr/share/clearwater/utils/check-root-permissions [exit_code]
 #

--- a/clearwater-infrastructure/usr/share/clearwater/utils/check-root-permissions
+++ b/clearwater-infrastructure/usr/share/clearwater/utils/check-root-permissions
@@ -1,0 +1,53 @@
+# @file check-root-permissions
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# Usage:
+#
+# To use this script, add the following a bash file:
+#
+# . /usr/share/clearwater/utils/check-root-permissions [exit_code]
+#
+# where exit_code is the code to exit the script with it fails as it needs root
+# permissions.
+
+if [ $EUID -ne 0 ]
+then
+  echo "You must run this script with root permissions"
+  if [ "$#" -ne 0 ]
+  then
+    exit $1
+  fi
+
+  exit 1
+fi

--- a/clearwater-infrastructure/usr/share/clearwater/utils/check-root-permissions
+++ b/clearwater-infrastructure/usr/share/clearwater/utils/check-root-permissions
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # @file check-root-permissions
 #
 # Project Clearwater - IMS in the Cloud
@@ -38,8 +40,8 @@
 #
 # . /usr/share/clearwater/utils/check-root-permissions [exit_code]
 #
-# where exit_code is the code to exit the script with it fails as it needs root
-# permissions.
+# where exit_code is the code to exit the script with if it detects the user
+# is not running as root
 
 if [ $EUID -ne 0 ]
 then


### PR DESCRIPTION
This fixes the desire raised in https://github.com/Metaswitch/clearwater-etcd-plugins/issues/9 to have a common method of checking for root permissions.

Usage as documented is:

```bash
. /usr/share/clearwater/utils/check-root-permissions [exit_code]
```

I've tested clearwater-upgrade live on a sprout node to check that this works.