### PR TITLE
[reviewer: Ellie] Poll http passes on 503 as well as 200 OK responses

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/poll-http
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/poll-http
@@ -42,9 +42,10 @@ address=$1
 . /etc/clearwater/config
 [ -z $signaling_namespace ] || namespace_prefix="ip netns exec $signaling_namespace"
 
-# Send HTTP request and check that the response is "OK".
+# Send HTTP request, writing the return code as well as the body to ensure we
+# catch overload correctly. Check that the response is "OK200" or "503".
 http_url=http://$address/ping
-$namespace_prefix curl -f -g -m 2 -s $http_url 2> /tmp/poll-http.sh.stderr.$$ | tee /tmp/poll-http.sh.stdout.$$ | head -1 | egrep -q "^OK$"
+$namespace_prefix curl -f -g -m 2 -s $http_url --write-out %{http_code} 2> /tmp/poll-http.sh.stderr.$$ | tee /tmp/poll-http.sh.stdout.$$ | head -1 | egrep -q "(^OK200$|^503$)"
 rc=$?
 
 # Check the return code and log if appropriate.


### PR DESCRIPTION
https://github.com/Metaswitch/sprout/issues/1570 saw poll_sprout_http failing fairly often, causing monit to kill the sprout process.
Chronos was also seen to be being repeatedly killed in GVD testing.

Tracing it back, we found that if we are overloaded in https://github.com/Metaswitch/cpp-common/blob/54371f20e89c60a04218bdeebe90d687f26345fc/src/httpstack.cpp#L313  we will return a 503 response with no body, where the 'ping' poll would normally return a 200 with "OK" in the body.

In https://github.com/Metaswitch/clearwater-infrastructure/blob/master/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip#L77 , the poll-sip script already checks for either a 200 or a 503 response, as the intent of the poll scripts is to check for liveness/responsiveness, not whether we are overloaded.

This has been tested by modifying the httpstack:313 to be `if(false)`, and then building chronos and sprout using this, so that they always return 503. Without the change below, the processes were repeatedly killed. With it, they were not.

