### PR TITLE
[Reviewer: Ellie] Use a sensible location when invoked with a HOME dir

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
@@ -35,7 +35,23 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 DIAGS_LOCATION=/var/clearwater-diags-monitor/dumps/
-DIAGS_END_LOCATION=${HOME}/ftp/dumps/
+
+# In some scenarios we are run as root, and $HOME is not defined.
+# Instead, we should create a dump in the Clearwater user's directory.
+if [ ! -z $HOME ]
+then
+  CLEARWATER_USER_HOME=$HOME
+elif [ -d /home/clearwater ]
+then
+  CLEARWATER_USER_HOME=/home/clearwater
+elif [ -d /home/centos ]
+then
+  CLEARWATER_USER_HOME=/home/centos
+else
+  CLEARWATER_USER_HOME=/home/ubuntu
+fi
+
+DIAGS_END_LOCATION=${CLEARWATER_USER_HOME}/ftp/dumps/
 
 if [ $# -ne 0 ]
 then


### PR DESCRIPTION
Ellie,

This resolves a bug you saw when we weren't dumping diags to the correct location.

If we don't have $HOME defined when this script is invoked, we should still place the diags in the correct location. As such, we have a search list of places we look for to work out where to place the diagnostics bundle.

I've tested live on a Project Clearwater system spun up on EC2