### PR TITLE
[Reviewer: Graeme] Enforce that run-in-signaling-namespace is run with sudo permissions

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/run-in-signaling-namespace
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/run-in-signaling-namespace
@@ -36,5 +36,6 @@
 
 # Returns the namespace_prefix (only set if the signaling_namespace is in use).
 . /etc/clearwater/config
+. /usr/share/clearwater/utils/check-root-permissions 1
 [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
 $namespace_prefix $*

--- a/clearwater-infrastructure/usr/share/clearwater/bin/run-in-signaling-namespace
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/run-in-signaling-namespace
@@ -34,8 +34,9 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
+. /usr/share/clearwater/utils/check-root-permissions 1
+
 # Returns the namespace_prefix (only set if the signaling_namespace is in use).
 . /etc/clearwater/config
-. /usr/share/clearwater/utils/check-root-permissions 1
 [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
 $namespace_prefix $*


### PR DESCRIPTION
Adds permissions check to the run-in-signaling-namespace check. Tested live.