### PR TITLE
[Reviewer: Matt] Remove default entries in config file

### DIFF
--- a/clearwater-radius-auth/usr/share/clearwater/infrastructure/install/clearwater-radius-auth.postinst
+++ b/clearwater-radius-auth/usr/share/clearwater/infrastructure/install/clearwater-radius-auth.postinst
@@ -39,3 +39,10 @@
 sed -i "s/\(\(passwd\|shadow\).*\)/\1 ato/" /etc/nsswitch.conf
 # Adds a sufficient check for RADIUS authentication before the standard UNIX authentication.
 sed -i "3i# +clearwater-radius-auth\nauth sufficient pam_radius_auth.so\n# -clearwater-radius-auth\n" /etc/pam.d/sshd
+
+# If this is a fresh install, we will not have been called with the previous version.
+# In this case, we want to comment out the default entries in /etc/pam_radius_auth.conf
+if [ -z "$1" ]; then
+  echo "This is a fresh install of clearwater-radius-auth\nDisabling default entries in /etc/pam_radius_auth.conf"
+  sed -i "/^#/! s/^/# /" /etc/pam_radius_auth.conf
+fi

--- a/debian/clearwater-radius-auth.postinst
+++ b/debian/clearwater-radius-auth.postinst
@@ -53,7 +53,7 @@ set -e
 
 case "$1" in
     configure)
-        /usr/share/clearwater/infrastructure/install/clearwater-radius-auth.postinst
+        /usr/share/clearwater/infrastructure/install/clearwater-radius-auth.postinst $2
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Only runs on install, not on upgrade. 
The issue is at #407 . 

Tested live to make sure that we don't comment out any entries added to this config file after the initial install. 
If a user has installed libpam-radius-auth manually before they install cw-radius-auth this will comment out any additions to the config file they have made, but we do not suggest they do this. If it does happen, all they'd need to do is uncomment them again anyway.