### PR TITLE
[No reviewer] Remove calls to non-existent scripts

### DIFF
--- a/rpm/clearwater-radius-auth.spec
+++ b/rpm/clearwater-radius-auth.spec
@@ -15,16 +15,4 @@ setup_buildroot
 install_to_buildroot < %{rootdir}/debian/clearwater-radius-auth.install
 build_files_list > clearwater-radius-auth.files
 
-%post
-# Initial install, not upgrade
-if [ "$1" == 1 ] ; then
-  /usr/share/clearwater/infrastructure/install/clearwater-radius-auth.postinst
-fi
-
-%preun
-# Uninstall, not upgrade
-if [ "$1" == 0 ] ; then
-  /usr/share/clearwater/infrastructure/install/clearwater-radius-auth.prerm
-fi
-
 %files -f clearwater-radius-auth.files


### PR DESCRIPTION
Caught this doing some manual testing building some images.
yum reported an error running the postinst script. This is because the script no longer exists.

Should have been included in #410 but was missed. 
Tested building the RPM and installing on a CentOS machine. 