### PR TITLE
[Reviewer: Adam] Give autoconfig the new required config options

### DIFF
--- a/clearwater-auto-config/etc/clearwater/shared_config
+++ b/clearwater-auto-config/etc/clearwater/shared_config
@@ -7,6 +7,8 @@ xdms_hostname=
 ralf_hostname=
 chronos_hostname=
 cassandra_hostname=
+sprout_registration_store=localhost
+ralf_session_store=localhost
 
 # Email server configuration
 smtp_smarthost=127.0.0.1


### PR DESCRIPTION
Default sprout_registration_store and ralf_session_store to localhost (to preserve the behaviour that existed prior to the split-clusters merge)