### PR TITLE
[Reviewer: MGM] Fix up autoconfig

### DIFF
--- a/clearwater-auto-config/etc/clearwater/shared_config
+++ b/clearwater-auto-config/etc/clearwater/shared_config
@@ -8,6 +8,7 @@ ralf_hostname=
 chronos_hostname=
 cassandra_hostname=
 sprout_registration_store=
+ralf_session_store=
 
 # Email server configuration
 smtp_smarthost=127.0.0.1

--- a/debian/clearwater-auto-config-aws.init.d
+++ b/debian/clearwater-auto-config-aws.init.d
@@ -49,7 +49,7 @@
 do_auto_config()
 {
   mkdir -p /etc/clearwater
- 
+
   local_config=/etc/clearwater/local_config
   shared_config=/etc/clearwater/shared_config
 
@@ -66,6 +66,7 @@ do_auto_config()
           s/^xdms_hostname=.*$/xdms_hostname='$public_hostname':7888/g
           s/^hs_hostname=.*$/hs_hostname='$public_hostname':8888/g
           s/^hs_provisioning_hostname=.*$/hs_provisioning_hostname='$public_hostname':8889/g
+          s/^sprout_registration_store=.*$/sprout_registration_store='$public_hostname'/g
           s/^upstream_hostname=.*$/upstream_hostname='$public_hostname'/g' -i $shared_config
 
   # Sprout will replace the cluster-settings file with something appropriate when it starts

--- a/debian/clearwater-auto-config-docker.init.d
+++ b/debian/clearwater-auto-config-docker.init.d
@@ -113,6 +113,7 @@ do_auto_config()
       xdms_hostname=homer:7888
       upstream_hostname=scscf.sprout
       ralf_hostname=ralf:10888
+      ralf_session_store=astaire
       home_domain="example.com"
     else
       # Configure relative to the base zone and rely on externally configured DNS entries.
@@ -125,6 +126,7 @@ do_auto_config()
       xdms_hostname=homer.$ZONE:7888
       upstream_hostname=scscf.sprout.$ZONE
       ralf_hostname=ralf.$ZONE:10888
+      ralf_session_store=astaire.$ZONE
       home_domain=$ZONE
     fi
 
@@ -136,6 +138,7 @@ do_auto_config()
             s/^upstream_hostname=.*$/upstream_hostname='$upstream_hostname'/g
             s/^ralf_hostname=.*$/ralf_hostname='$ralf_hostname'/g
             s/^sprout_registration_store=.*$/sprout_registration_store='$sprout_registration_store'/g
+            s/^ralf_session_store=.*$/ralf_session_store='$ralf_session_store'/g
             s/^chronos_hostname=.*$/chronos_hostname='$chronos_hostname'/g
             s/^cassandra_hostname=.*$/cassandra_hostname='$cassandra_hostname'/g
             s/^email_recovery_sender=.*$/email_recovery_sender=clearwater@'$home_domain'/g' -i $shared_config

--- a/debian/clearwater-auto-config-generic.init.d
+++ b/debian/clearwater-auto-config-generic.init.d
@@ -74,6 +74,7 @@ do_auto_config()
           s/^xdms_hostname=.*$/xdms_hostname='$bracketed_ip':7888/g
           s/^hs_hostname=.*$/hs_hostname='$bracketed_ip':8888/g
           s/^hs_provisioning_hostname=.*$/hs_provisioning_hostname='$bracketed_ip':8889/g
+          s/^sprout_registration_store=.*$/sprout_registration_store='$bracketed_ip'/g
           s/^upstream_hostname=.*$/upstream_hostname=scscf.'$aio_hostname'/g' -i $shared_config
 
   # Sprout will replace the cluster-settings file with something appropriate when it starts


### PR DESCRIPTION
As mentioned in my comments on your PR, we need to add ralf_session_store to the docker autoconfig, and we need to then mirror the changes that we made to the docker autoconfig to the aws and generic ones too.

(Note that generic and aws don't have Ralf, so I haven't added the ralf_session_store to those).

I've created an AIO node and run the live tests against it to verify this.

I've set this as a PR into your branch as it's based off the changes you made.