### PR TITLE
[Reviewer: Ellie] Remove etcd data on reboots, so that saved images can boot with new IPs

### DIFF
--- a/debian/clearwater-auto-config-aws.init.d
+++ b/debian/clearwater-auto-config-aws.init.d
@@ -72,6 +72,9 @@ do_auto_config()
   # Sprout will replace the cluster-settings file with something appropriate when it starts
   rm -f /etc/clearwater/cluster_settings
 
+  # Ensure that we start a clean cluster, so that cloned AIO nodes etc. boot cleanly
+  rm -rf /var/lib/clearwater-etcd/
+
   # Set up DNS for the S-CSCF
   grep -v ' #+scscf.aio$' /etc/hosts > /tmp/hosts.$$
   echo $local_ip scscf.$public_hostname '#+scscf.aio'>> /tmp/hosts.$$

--- a/debian/clearwater-auto-config-aws.init.d
+++ b/debian/clearwater-auto-config-aws.init.d
@@ -73,7 +73,7 @@ do_auto_config()
   rm -f /etc/clearwater/cluster_settings
 
   # Ensure that we start a clean cluster, so that cloned AIO nodes etc. boot cleanly
-  rm -rf /var/lib/clearwater-etcd/
+  rm -rf /var/lib/clearwater-etcd/*
 
   # Set up DNS for the S-CSCF
   grep -v ' #+scscf.aio$' /etc/hosts > /tmp/hosts.$$

--- a/debian/clearwater-auto-config-generic.init.d
+++ b/debian/clearwater-auto-config-generic.init.d
@@ -81,7 +81,7 @@ do_auto_config()
   rm -f /etc/clearwater/cluster_settings
 
   # Ensure that we start a clean cluster, so that cloned AIO nodes etc. boot cleanly
-  rm -rf /var/lib/clearwater-etcd/
+  rm -rf /var/lib/clearwater-etcd/*
 
   # Set up DNS for the S-CSCF
   grep -v ' #+clearwater-aio$' /etc/hosts > /tmp/hosts.$$

--- a/debian/clearwater-auto-config-generic.init.d
+++ b/debian/clearwater-auto-config-generic.init.d
@@ -80,6 +80,9 @@ do_auto_config()
   # Sprout will replace the cluster-settings file with something appropriate when it starts
   rm -f /etc/clearwater/cluster_settings
 
+  # Ensure that we start a clean cluster, so that cloned AIO nodes etc. boot cleanly
+  rm -rf /var/lib/clearwater-etcd/
+
   # Set up DNS for the S-CSCF
   grep -v ' #+clearwater-aio$' /etc/hosts > /tmp/hosts.$$
   echo $ip $aio_hostname '#+clearwater-aio'>> /tmp/hosts.$$


### PR DESCRIPTION
We discussed this fix last week. I have built an AMI from this code, and tested. All services report they are working, and etcd clusters fine. 
