### PR TITLE
[Reviewer: Seb] Use sprout-base to identify sprout

### DIFF
--- a/clearwater-infrastructure/etc/bash.bashrc.clearwater
+++ b/clearwater-infrastructure/etc/bash.bashrc.clearwater
@@ -15,10 +15,13 @@ type=$(. /etc/clearwater/config
          fi
        } |
        # Filter out the packages we care about
-       egrep '^(bono|clearwater-sip-stress|ellis|homer|homestead|sprout|stats-engine|ralf|chronos|cassandra|astaire)$' |
+       # Use sprout-base instead of sprout to catch all cases of sprout being
+       # installed
+       egrep '^(bono|clearwater-sip-stress|ellis|homer|homestead|sprout-base|stats-engine|ralf|chronos|cassandra|astaire)$' |
        # Shorten the constructed name and replace product names containing
        # hyphens.
        sed -e 's/clearwater-sip-stress/sipp/g' |
+       sed -e 's/sprout-base/sprout/g' |
        sed -e 's/stats-engine/mvse/g' |
        tr "\\n" "-" |
 


### PR DESCRIPTION
Seb,

If you only install certain components of Sprout (e.g. the I-CSCF and the S-CSCF), we won't detect the node as being sprout.

Instead, check for sprout-base.

