### PR TITLE
[Reviewer: Seb] Include hard disk size in diags

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -326,6 +326,7 @@ get_hardware_info()
   cat /proc/cpuinfo > $CURRENT_DUMP_DIR/cpuinfo.txt
   cat /proc/meminfo > $CURRENT_DUMP_DIR/meminfo.txt
   df -kh            > $CURRENT_DUMP_DIR/df-kh.txt
+  fdisk -l          > $CURRENT_DUMP_DIR/fdisk-l.txt
 }
 
 # Get historical resource usage stats. This includes things like network usage,


### PR DESCRIPTION
Seb,

It'd be useful to have the actual size of the hard disk and the partitions that it's running on to ensure that the VM was setup correctly when Clearwater was installed.

This should give us output along the lines of:

```
Disk /dev/sda: 21.5 GB, 21474836480 bytes
255 heads, 63 sectors/track, 2610 cylinders, total 41943040 sectors
Units = sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disk identifier: 0x00000000
```