### PR TITLE
[Reviewer: Seb] Check for the database, not for the user of the database

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -606,7 +606,7 @@ do
   get_process_info
 
   # Database statuses.
-  if cw_component_installed homer homestead memento
+  if cw_component_installed clearwater-cassandra
   then
     get_cassandra_info
   fi
@@ -616,7 +616,7 @@ do
     get_mysql_info
   fi
 
-  if cw_component_installed sprout ralf memento
+  if cw_component_installed memcached
   then
     get_memcached_info
   fi


### PR DESCRIPTION
This PR changes the diags monitor to check whether the database is installed when deciding whether to collect diags, not whether the user of the database is installed.

(A better fix would be to move this into the database repo itself (e.g. https://github.com/Metaswitch/chronos/blob/dev/chronos.root/usr/share/clearwater/clearwater-diags-monitor/scripts/chronos_diags), but I'm not going to do that here - this PR covers fixing up the immediate problem)