### PR TITLE
Collect checksum diags for RPMs on Centos

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -317,19 +317,21 @@ get_cw_package_checksums()
 {
   # For Centos the --verify flag for the rpm command returns several
   # verification diags, including MD5 checksum problems (labelled with a `5`).
+  # See https://linux.die.net/man/8/rpm for other flags description.
   {
     if which rpm > /dev/null ; then
-    for pkg in $(clearwater_packages)
-    do
-      rpm --verify $pkg
-    done
-  fi
-  } >> $CURRENT_DUMP_DIR/rpm_verification.txt
+      for pkg in $(clearwater_packages)
+      do
+        rpm --verify "$pkg"
+      done
+    fi
+  } >> "$CURRENT_DUMP_DIR"/rpm_verification.txt
+
   # For Debian just collect the MD5 checksums
   if which dpkg > /dev/null ; then
     for pkg in $(clearwater_packages)
     do
-      cp -p /var/lib/dpkg/info/$pkg.md5sums $CURRENT_DUMP_DIR
+      cp -p /var/lib/dpkg/info/"$pkg".md5sums "$CURRENT_DUMP_DIR"
     done
   fi
 }

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -315,9 +315,8 @@ get_ntp_status()
 # system.
 get_cw_package_checksums()
 {
-  # For RPM the --verify flag includes several verifications, including a `5`
-  # indicating files that have an MD5 checksum problem.
-  rpm_verification_file=
+  # For Centos the --verify flag for the rpm command returns several
+  # verification diags, including MD5 checksum problems (labelled with a `5`).
   {
     if which rpm > /dev/null ; then
     for pkg in $(clearwater_packages)
@@ -326,7 +325,7 @@ get_cw_package_checksums()
     done
   fi
   } >> $CURRENT_DUMP_DIR/rpm_verification.txt
-  # This isn't supported function under RPM, so only do it for Debian
+  # For Debian just collect the MD5 checksums
   if which dpkg > /dev/null ; then
     for pkg in $(clearwater_packages)
     do

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -52,7 +52,7 @@ MIN_IDLE_CPU_FOR_GATHER=40
 . /etc/clearwater/config || exit
 
 # Setup prefix to use when running commands that need to execute within
-# the signaling network namespace for multi-interface configurations. 
+# the signaling network namespace for multi-interface configurations.
 [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
 
 # Setup dig's server argument for when it needs to execute within the
@@ -315,6 +315,17 @@ get_ntp_status()
 # system.
 get_cw_package_checksums()
 {
+  # For RPM the --verify flag includes several verifications, including a `5`
+  # indicating files that have an MD5 checksum problem.
+  rpm_verification_file=
+  {
+    if which rpm > /dev/null ; then
+    for pkg in $(clearwater_packages)
+    do
+      rpm --verify $pkg
+    done
+  fi
+  } >> $CURRENT_DUMP_DIR/rpm_verification.txt
   # This isn't supported function under RPM, so only do it for Debian
   if which dpkg > /dev/null ; then
     for pkg in $(clearwater_packages)


### PR DESCRIPTION
Hi Chris, this PR is fixing https://github.com/Metaswitch/stats-engine/issues/473, i.e. it includes further diags for Centos in the diagnostics package. Until now we didn't have any checksum diags for Centos, which we now get (plus further diags) as a file `rpm_verification.txt` in the diags bundle. I have live tested my fix and got this output in `rpm_verification.txt` (which shows me that my manipulated file actually doesn't have a matching checksum :-) ):
```
S.5....T.    /usr/share/clearwater/bin/clearwater_diags_monitor
.......T.    /usr/share/clearwater/bin/gather_diags
.M.......  c /etc/monit/monitrc
.M.......    /usr/share/clearwater/stats-engine/fv/Gemfile
.M.......    /usr/share/clearwater/stats-engine/fv/Gemfile.lock
.M.......    /usr/share/clearwater/stats-engine/fv/fake_node_instance.rb
.M.......    /usr/share/clearwater/stats-engine/fv/request_handler_fv.rb
.M.......    /usr/share/clearwater/stats-engine/fv/stats-engine_fv.rb
.M.......    /usr/share/clearwater/stats-engine/fv/streamed_stat.rb
```