### PR TITLE
Fix up output and sudo location of gather_diags_and_report_location

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
@@ -11,12 +11,13 @@
 
 DIAGS_LOCATION=/var/clearwater-diags-monitor/dumps/
 
-# In some scenarios we are run as root, and $HOME is not defined.
-# Instead, we should create a dump in the Clearwater user's directory.
-if [ ! -z $SUDO_USER ]
+# We always want to create a dump in the clearwater user's directory,
+# irrespective of whether or not the command was run with sudo.
+if [ -n $SUDO_USER ]
 then
+  # Evaluate the SUDO_USER's home directory and assign to CLEARWATER_USER_HOME.
   eval CLEARWATER_USER_HOME="~$SUDO_USER"
-elif [ ! -z $HOME ]
+elif [ -n $HOME ]
 then
   CLEARWATER_USER_HOME=$HOME
 elif [ -d /home/clearwater ]

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
@@ -13,7 +13,10 @@ DIAGS_LOCATION=/var/clearwater-diags-monitor/dumps/
 
 # In some scenarios we are run as root, and $HOME is not defined.
 # Instead, we should create a dump in the Clearwater user's directory.
-if [ ! -z $HOME ]
+if [ ! -z $SUDO_USER ]
+then
+  eval CLEARWATER_USER_HOME="~$SUDO_USER"
+elif [ ! -z $HOME ]
 then
   CLEARWATER_USER_HOME=$HOME
 elif [ -d /home/clearwater ]

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
@@ -39,7 +39,7 @@ fi
 current_time=$(date --utc "+%Y%m%d%H%M%S")
 
 # Write a file to trigger a diagnostic dump.
-echo "Collecting diagnostics from the system.\n"
+echo "Collecting diagnostics from the system."
 echo "This operation can take a few minutes to run."
 echo "Manually triggered by /usr/share/clearwater/bin/gather_diags" > /var/clearwater-diags-monitor/tmp/core.gather_diags.$(date +%s)
 
@@ -62,4 +62,4 @@ mkdir -p $DIAGS_END_LOCATION
 
 cp $DIAGS_LOCATION$latest_diags_file $DIAGS_END_LOCATION
 
-echo "\nDiagnostics collected. These are available at $DIAGS_END_LOCATION$latest_diags_file"
+echo -e "\nDiagnostics collected. These are available at $DIAGS_END_LOCATION$latest_diags_file"


### PR DESCRIPTION
Hi Rob, this PR is fixing https://github.com/Metaswitch/stats-engine/issues/668: The output of `gather_diags_and_report_location` used to look like this:
```
[mvse]defcraft@localhost:~$ sudo /usr/share/clearwater/bin/gather_diags_and_report_location
Collecting diagnostics from the system.\n
This operation can take a few minutes to run.
.......................\nDiagnostics collected. These are available at /root/ftp/dumps/20170606155847Z.BEN-MVSE.gather_diags.tar.gz
```

This pull request fixes up the output:
```
[defcraft@md6-08-07-17 ~]$ sudo /usr/share/clearwater/bin/gather_diags_and_report_location
Collecting diagnostics from the system.
This operation can take a few minutes to run.
.................
Diagnostics collected. These are available at /root/ftp/dumps/20170608150003Z.md6-08-07-17.gather_diags.tar.gz
```