### PR TITLE
Remove UTC flag in gather_diags_and_report_location  to get local time

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
@@ -40,7 +40,7 @@ then
 fi
 
 # Store the current time
-current_time=$(date --utc "+%Y%m%d%H%M%S")
+current_time=$(date "+%Y%m%d%H%M%S")
 
 # Write a file to trigger a diagnostic dump.
 echo "Collecting diagnostics from the system."


### PR DESCRIPTION
Hi Chris, can you please have a very quick look at this tiny code change (as Rob is off and Ken is full-time on MVS)? Ben retested my changes for the `gather_diags_and_report_location` script in https://github.com/Metaswitch/stats-engine/issues/668 and noticed that I forgot to fix one of the issues originally asked for a fix: The diags package name used UTC instead of the local time.
I have live tested my fix and it works fine:
```
[defcraft@md6-08-07-17 bin]$ date
Tue Jun 13 16:11:14 UTC 2017
[defcraft@md6-08-07-17 bin]$ ./gather_diags_and_report_location
Collecting diagnostics from the system.
This operation can take a few minutes to run.
.....................................
Diagnostics collected. These are available at /home/defcraft/ftp/dumps/20170613161149Z.md6-08-07-17.gather_diags.tar.gz
[defcraft@md6-08-07-17 bin]$ date
Tue Jun 13 16:12:40 UTC 2017
```