### PR TITLE
[Reviewer: Seb] Fix check for presence of /etc/skel

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/install/clearwater-infrastructure.postinst
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/install/clearwater-infrastructure.postinst
@@ -48,7 +48,7 @@ for HOME_DIR in $(find /home -mindepth 1 -maxdepth 1 -type d) ; do
   fi
 done
 
-if [ ! -d /etc/skel ]; then
+if [ -d /etc/skel ]; then
   add_bashrc_shim /etc/skel/.bashrc
 fi
 


### PR DESCRIPTION
Seb,

Currently the check for whether /etc/skel exists is incorrect - and thus we don't add the bashrc change to new users.