### PR TITLE
Change file type

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # @file gather_diags_and_report_location
 #


### PR DESCRIPTION
There's a rogue -e in the gather_diags output that's coming from https://github.com/Metaswitch/clearwater-infrastructure/blob/master/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location#L69.

Putting -e in echo should mean that it's able to turn \n into newline characters (http://manpages.ubuntu.com/manpages/trusty/man1/echo.1.html). 

We're using the wrong shell though; this PR fixes that.

Tested live on ubuntu/centos