### PR TITLE
Force clearwater-infrastructure to run after cloud-init.

### DIFF
--- a/debian/clearwater-infrastructure.init.d
+++ b/debian/clearwater-infrastructure.init.d
@@ -9,6 +9,11 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
+# On systems running cloud-init, some of the configuration set by
+# clearwater-infrastructure, e.g. hostname, is also managed by cloud-init.
+# In order to avoid cloud-init overwriting these settings, we ask the init
+# system to run clearwater-infrastructure after cloud-init has finished.
+
 ### BEGIN INIT INFO
 # Provides:          clearwater-infrastructure
 # Required-Start:    $network $local_fs

--- a/debian/clearwater-infrastructure.init.d
+++ b/debian/clearwater-infrastructure.init.d
@@ -13,6 +13,7 @@
 # Provides:          clearwater-infrastructure
 # Required-Start:    $network $local_fs
 # Required-Stop:
+# Should-Start:      cloud-init
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Clearwater infrastructure


### PR DESCRIPTION
On servers using systemd as their init system, systemd generates unit
information for legacy sysvinit-style scripts based on the LSB headers
in the scripts. It uses the dependencies in the scripts to ensure that
legacy services are started at the right point.

If clearwater-infrastructure is used without clearwater-startup, on a
system using cloud-init then it's important that clearwater-infrastructure is
started after cloud-init has finished, so that cloud-init doesn't
overwrite the configuration set up by clearwater-infrastructure, in
particular the hostname of the system as defined by the field
`public_hostname` in /etc/clearwater/local_config.

Adding this header should not affect systems running upstart as an init
system (e.g. Ubuntu 14.04), because upstart uses the runlevel to
trigger legacy init scripts rather than building a dependency graph
like systemd.