### PR TITLE
[Reviewer: Sathiyan] Add iotop stats collections

### DIFF
--- a/clearwater-diags-monitor/etc/cron.d/clearwater-iotop
+++ b/clearwater-diags-monitor/etc/cron.d/clearwater-iotop
@@ -1,0 +1,2 @@
+# Get iotop reports every minute
+* * * * * root /usr/sbin/iotop -b -o -t -n 1 -k >> /var/log/iotop.log 2>&1

--- a/clearwater-diags-monitor/etc/logrotate.d/clearwater-iotop
+++ b/clearwater-diags-monitor/etc/logrotate.d/clearwater-iotop
@@ -1,0 +1,11 @@
+/var/log/clearwater-iotop.log
+{
+        rotate 4
+        maxsize 10M
+        weekly
+        missingok
+        notifempty
+        compress
+        delaycompress
+        copytruncate
+}

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Description: SNMP service for Clearwater CPU, RAM and I/O statistics
 
 Package: clearwater-diags-monitor
 Architecture: all
-Depends: inotify-tools, realpath, sysstat, clearwater-infrastructure, clearwater-monit, gzip
+Depends: inotify-tools, realpath, sysstat, clearwater-infrastructure, clearwater-monit, gzip, iotop
 Description: Diagnostics monitor and bundler for all Clearwater servers
 
 Package: clearwater-socket-factory


### PR DESCRIPTION
This collects iotop stats every minute, which is useful for debugging etcd issues. 
The existing diags monitor code ensures that these are in any diags dumps.