### PR TITLE
[Reviewer: Seb] Quote bash variables so that -n evaluates correctly

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/gather_diags_and_report_location
@@ -13,11 +13,11 @@ DIAGS_LOCATION=/var/clearwater-diags-monitor/dumps/
 
 # We always want to create a dump in the clearwater user's directory,
 # irrespective of whether or not the command was run with sudo.
-if [ -n $SUDO_USER ]
+if [ -n "$SUDO_USER" ]
 then
   # Evaluate the SUDO_USER's home directory and assign to CLEARWATER_USER_HOME.
   eval CLEARWATER_USER_HOME="~$SUDO_USER"
-elif [ -n $HOME ]
+elif [ -n "$HOME" ]
 then
   CLEARWATER_USER_HOME=$HOME
 elif [ -d /home/clearwater ]


### PR DESCRIPTION
Seb,

This resolves an issue whereby if SUDO_USER and HOME is not defined, then the diags will be dumped to an incorrect place.

This is because the "! -z" check was changed "-n" in https://github.com/Metaswitch/clearwater-infrastructure/pull/458

However, these two checks are not identical when checking whether is a string is empty if the string isn't quoted - see the warning on http://tldp.org/LDP/abs/html/comparison-ops.html and the difference between 5a and 3b in the comparison table given by https://stackoverflow.com/a/3870055.

In short

- `[ -n ]` passes (which is what the current code evaluates to
- `[ ! -z ]` fails,
- `[ -n "" ]` fails
- `[ ! -z "" ]` fails.

This is resolved by quoting the string.