### PR TITLE
[Reviewer: EM] Disable SSL 3.0 in freeDiameter config

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/generic_create_diameterconf
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/generic_create_diameterconf
@@ -101,7 +101,7 @@ then
   acl_commenter=""
 fi
 
-# By default assume that the Destination-Host AVP should be checked on incoming requests, 
+# By default assume that the Destination-Host AVP should be checked on incoming requests,
 # so comment out the rt_change_dh.fdx Load Extension line. If ignoring the Destination-Host
 # is allowed, uncomment it.
 dh_commenter="#";
@@ -123,6 +123,7 @@ SecPort = $sec_port;
 # TLS configuration
 TLS_Cred = "$key_dir/cert.pem", "$key_dir/privkey.pem";
 TLS_CA = "$key_dir/ca.pem";
+TLS_Prio = "NORMAL:-VERS-SSL3.0";
 
 # Limit the number of SCTP streams
 SCTP_streams = 3;


### PR DESCRIPTION
@eleanor-merry, I've assigned you as the suggested reviewer by Github - if you're not the right person, please let me know.

This adds a line to our freeDiameter config to disable SSL 3.0. This mitigates the susceptibility to the POODLE security vulnerability. I have confirmed that this works as intended by:

* Pasting the below change into the `/usr/share/clearwater/bin/generic_create_diameterconf` file on a Dime node;
* Rebooting the Dime node, refreshing the diameter config for all applicable services;
* Running nmap against the node for ports 5658 (homestead) and 5659 (ralf).

Before applying the fix, nmap flagged the above ports; afterwards, it comes up clean. I have also run the live tests to check that function is not impacted.