### PR TITLE
[Reviewer: AJH] Disable memcached listening on UDP

### DIFF
--- a/clearwater-memcached/etc/clearwater/secure-connections/memcached.conf
+++ b/clearwater-memcached/etc/clearwater/secure-connections/memcached.conf
@@ -1,8 +1,4 @@
-# Secure all UDP and TCP traffic on port 11211 (memcached).
-spdadd 0.0.0.0/0[any] 0.0.0.0/0[11211] udp -P in ipsec esp/transport//require;
-spdadd 0.0.0.0/0[11211] 0.0.0.0/0[any] udp -P in ipsec esp/transport//require;
-spdadd 0.0.0.0/0[any] 0.0.0.0/0[11211] udp -P out ipsec esp/transport//require;
-spdadd 0.0.0.0/0[11211] 0.0.0.0/0[any] udp -P out ipsec esp/transport//require;
+# Secure all TCP traffic on port 11211 (memcached). We don't listen over UDP, so don't need to secure it.
 spdadd 0.0.0.0/0[any] 0.0.0.0/0[11211] tcp -P in ipsec esp/transport//require;
 spdadd 0.0.0.0/0[11211] 0.0.0.0/0[any] tcp -P in ipsec esp/transport//require;
 spdadd 0.0.0.0/0[any] 0.0.0.0/0[11211] tcp -P out ipsec esp/transport//require;

--- a/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
@@ -25,4 +25,6 @@ sed -e 's/^-l .*$/-l '$listen_address'/g'\
     -e 's/^# *-v *$/-v/g'\
     -e 's/^\(# *\|\)-c.*$/-c 4096/g' </etc/memcached.conf >/etc/memcached_11211.conf
 
+echo "\n# Disable listening on UDP\n-U 0" >> /etc/memcached_11211.conf
+
 echo "START_PREFIX=/usr/share/clearwater/bin/run-in-signaling-namespace" > /etc/default/memcached

--- a/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
@@ -25,6 +25,6 @@ sed -e 's/^-l .*$/-l '$listen_address'/g'\
     -e 's/^# *-v *$/-v/g'\
     -e 's/^\(# *\|\)-c.*$/-c 4096/g' </etc/memcached.conf >/etc/memcached_11211.conf
 
-echo "\n# Disable listening on UDP\n-U 0" >> /etc/memcached_11211.conf
+printf "\n# Disable listening on UDP\n-U 0" >> /etc/memcached_11211.conf
 
 echo "START_PREFIX=/usr/share/clearwater/bin/run-in-signaling-namespace" > /etc/default/memcached

--- a/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
@@ -25,6 +25,6 @@ sed -e 's/^-l .*$/-l '$listen_address'/g'\
     -e 's/^# *-v *$/-v/g'\
     -e 's/^\(# *\|\)-c.*$/-c 4096/g' </etc/memcached.conf >/etc/memcached_11211.conf
 
-printf "\n# Disable listening on UDP\n-U 0" >> /etc/memcached_11211.conf
+printf "\n# Disable listening on UDP\n-U 0\n" >> /etc/memcached_11211.conf
 
 echo "START_PREFIX=/usr/share/clearwater/bin/run-in-signaling-namespace" > /etc/default/memcached


### PR DESCRIPTION
@AlexHockey, I've assigned to you as the listed memcached expert - please let me know if you're not the right person to take this.

We only contact memcached over TCP, so we don't need it to be listening on UDP ports. By adding `-U 0` to the configuration file, memcached won't listen on any UDP ports.

Due to this change, we don't need to secure any of the UDP traffic in 11211, so I've also removed those rules.