### PR TITLE
[Reviewer: Ellie] Update AIO nodes to not require SRV records

### DIFF
--- a/clearwater-auto-config/etc/clearwater/shared_config
+++ b/clearwater-auto-config/etc/clearwater/shared_config
@@ -18,6 +18,9 @@ email_recovery_sender=clearwater@example.com
 
 # I-CSCF/S-CSCF configuration
 upstream_hostname=
+scscf_uri=
+icscf_uri=
+bgcf_uri=
 
 # Keys
 signup_key=secret

--- a/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
+++ b/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
@@ -69,7 +69,7 @@ write_config()
   add_section_text \
     /etc/hosts \
     "clearwater-aio" \
-    "$arg_local_ip $public_hostname ${scsf_prefix}.${public_hostname}"
+    "$arg_local_ip $public_hostname ${scscf_prefix}.${public_hostname}"
 
   service dnsmasq restart
 }

--- a/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
+++ b/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
@@ -56,7 +56,7 @@ write_config()
           s/^upstream_hostname=.*$/upstream_hostname='$arg_upstream_hostname'/g
           s/^scscf_uri=.*/scscf_uri=sip:'$scscf_prefix'.'$arg_public_hostname':'$scscf';transport=TCP/g
           s/^icscf_uri=.*/icscf_uri=sip:'$icscf_prefix'.'$arg_public_hostname':'$icscf';transport=TCP/g
-          s/^bgcf_uri=.*/icscf_uri=sip:'$bgcf_prefix'.'$arg_public_hostname':'$bgcf';transport=TCP/g
+          s/^bgcf_uri=.*/bgcf_uri=sip:'$bgcf_prefix'.'$arg_public_hostname':'$bgcf';transport=TCP/g
           ' -i $shared_config
 
   # Cluster Manager will replace the cluster_settings file with something appropriate when it starts

--- a/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
+++ b/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+# @file init-functions
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+# This file provides basic shared init functionality between the different
+# auto-config varieties
+
+# Include basic functions to add and remove sections from files
+. /usr/share/clearwater-auto-config/bin/common
+
+write_config()
+{
+  # Save off the arguments
+  arg_local_ip=$1
+  arg_public_ip=$2
+  arg_public_hostname=$3
+  # This can either be a FQDN or an IP but it must resolve to
+  # this node. If it's an IPv6 address, it must be bracketed
+  arg_address=$4
+  arg_upstream_hostname=$5
+
+  mkdir -p /etc/clearwater
+
+  # Allow the user to alter the default config by adding additional config
+  scscf=5054
+  scscf_prefix=scscf
+  icscf=5052
+  icscf_prefix=icscf
+  bgcf=5053
+  bgcf_prefix=bgcf
+
+  if [ -f /etc/clearwater/config ]; then
+    . /etc/clearwater/config
+  fi
+
+  local_config=/etc/clearwater/local_config
+  shared_config=/etc/clearwater/shared_config
+
+  sed -e 's/^local_ip=.*$/local_ip='$arg_local_ip'/g
+          s/^public_ip=.*$/public_ip='$arg_public_ip'/g
+          s/^etcd_cluster=.*$/etcd_cluster='$arg_local_ip'/g
+          s/^public_hostname=.*$/public_hostname='$arg_public_hostname'/g' -i $local_config
+
+  sed -e 's/^sprout_hostname=.*$/sprout_hostname='$arg_public_hostname'/g
+          s/^xdms_hostname=.*$/xdms_hostname='$arg_address':7888/g
+          s/^hs_hostname=.*$/hs_hostname='$arg_addresse':8888/g
+          s/^hs_provisioning_hostname=.*$/hs_provisioning_hostname='$arg_address':8889/g
+          s/^sprout_registration_store=.*$/sprout_registration_store='$arg_address'/g
+          s/^upstream_hostname=.*$/upstream_hostname='$arg_upstream_hostname'/g
+          s/^scscf_uri=.*/scscf_uri=sip:'$scscf_prefix'.'$arg_public_hostname':'$scscf';transport=TCP/g
+          s/^icscf_uri=.*/icscf_uri=sip:'$icscf_prefix'.'$arg_public_hostname':'$icscf';transport=TCP/g
+          s/^bgcf_uri=.*/icscf_uri=sip:'$bgcf_prefix'.'$arg_public_hostname':'$bgcf';transport=TCP/g
+          ' -i $shared_config
+
+  # Sprout will replace the cluster-settings file with something appropriate when it starts
+  rm -f /etc/clearwater/cluster_settings
+
+  # Ensure that we start a clean cluster, so that cloned AIO nodes etc. boot cleanly
+  rm -rf /var/lib/clearwater-etcd/*
+
+  # Set up DNS for the S-CSCF
+  add_section_text \
+    /etc/hosts \
+    "clearwater-aio" \
+    "$arg_local_ip $public_hostname ${scsf_prefix}.${public_hostname}"
+
+  service dnsmasq restart
+}

--- a/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
+++ b/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
@@ -50,7 +50,7 @@ write_config()
 
   sed -e 's/^sprout_hostname=.*$/sprout_hostname='$arg_public_hostname'/g
           s/^xdms_hostname=.*$/xdms_hostname='$arg_address':7888/g
-          s/^hs_hostname=.*$/hs_hostname='$arg_addresse':8888/g
+          s/^hs_hostname=.*$/hs_hostname='$arg_address':8888/g
           s/^hs_provisioning_hostname=.*$/hs_provisioning_hostname='$arg_address':8889/g
           s/^sprout_registration_store=.*$/sprout_registration_store='$arg_address'/g
           s/^upstream_hostname=.*$/upstream_hostname='$arg_upstream_hostname'/g
@@ -59,7 +59,7 @@ write_config()
           s/^bgcf_uri=.*/icscf_uri=sip:'$bgcf_prefix'.'$arg_public_hostname':'$bgcf';transport=TCP/g
           ' -i $shared_config
 
-  # Sprout will replace the cluster-settings file with something appropriate when it starts
+  # Cluster Manager will replace the cluster_settings file with something appropriate when it starts
   rm -f /etc/clearwater/cluster_settings
 
   # Ensure that we start a clean cluster, so that cloned AIO nodes etc. boot cleanly

--- a/debian/clearwater-auto-config-aws.init.d
+++ b/debian/clearwater-auto-config-aws.init.d
@@ -20,42 +20,21 @@
 # X-Start-Before:    clearwater-infrastructure bono sprout homer homestead ellis restund
 ### END INIT INFO
 
+. /usr/share/clearwater-auto-config/bin/init-functions
+
 # Changes in this command should be replicated in clearwater-auto-config-*.init.d
 do_auto_config()
 {
-  mkdir -p /etc/clearwater
-
-  local_config=/etc/clearwater/local_config
-  shared_config=/etc/clearwater/shared_config
-
   local_ip=$(wget -qO - http://169.254.169.254/latest/meta-data/local-ipv4)
   public_ip=$(wget -qO - http://169.254.169.254/latest/meta-data/public-ipv4)
   public_hostname=$(wget -qO - http://169.254.169.254/latest/meta-data/public-hostname)
 
-  sed -e 's/^local_ip=.*$/local_ip='$local_ip'/g
-          s/^public_ip=.*$/public_ip='$public_ip'/g
-          s/^etcd_cluster=.*$/etcd_cluster='$local_ip'/g
-          s/^public_hostname=.*$/public_hostname='$public_hostname'/g' -i $local_config
-
-  sed -e 's/^sprout_hostname=.*$/sprout_hostname='$public_hostname'/g
-          s/^xdms_hostname=.*$/xdms_hostname='$public_hostname':7888/g
-          s/^hs_hostname=.*$/hs_hostname='$public_hostname':8888/g
-          s/^hs_provisioning_hostname=.*$/hs_provisioning_hostname='$public_hostname':8889/g
-          s/^sprout_registration_store=.*$/sprout_registration_store='$public_hostname'/g
-          s/^upstream_hostname=.*$/upstream_hostname='$public_hostname'/g' -i $shared_config
-
-  # Sprout will replace the cluster-settings file with something appropriate when it starts
-  rm -f /etc/clearwater/cluster_settings
-
-  # Ensure that we start a clean cluster, so that cloned AIO nodes etc. boot cleanly
-  rm -rf /var/lib/clearwater-etcd/*
-
-  # Set up DNS for the S-CSCF
-  grep -v ' #+scscf.aio$' /etc/hosts > /tmp/hosts.$$
-  echo $local_ip scscf.$public_hostname '#+scscf.aio'>> /tmp/hosts.$$
-  mv /tmp/hosts.$$ /etc/hosts
-
-  service dnsmasq restart
+  write_config \
+    $local_ip \
+    $public_ip \
+    $public_hostname \
+    $public_hostname \
+    $public_hostname
 }
 
 case "$1" in

--- a/debian/clearwater-auto-config-aws.install
+++ b/debian/clearwater-auto-config-aws.install
@@ -1,1 +1,2 @@
 clearwater-auto-config/* /
+clearwater-infrastructure/usr/share/clearwater/infrastructure/install/common /usr/share/clearwater-auto-config/bin/

--- a/debian/clearwater-auto-config-docker.init.d
+++ b/debian/clearwater-auto-config-docker.init.d
@@ -122,6 +122,8 @@ do_auto_config()
     echo "scscf_uri=\"sip:$sprout_hostname:5054;transport=tcp\"" >> $shared_config
     sed -e '/^icscf_uri=.*/d' -i $shared_config
     echo "icscf_uri=\"sip:$sprout_hostname:5052;transport=tcp\"" >> $shared_config
+    sed -e '/^bgcf_uri=.*/d' -i $shared_config
+    echo "bgcf_uri=\"sip:$sprout_hostname:5053;transport=tcp\"" >> $shared_config
 
     if [ -n "$nameserver" ]
     then

--- a/debian/clearwater-auto-config-generic.install
+++ b/debian/clearwater-auto-config-generic.install
@@ -1,3 +1,4 @@
 clearwater-auto-config/* /
 build/bin/bracket-ipv6-address /usr/share/clearwater/clearwater-auto-config-generic/bin/
 build/bin/is-address-ipv6 /usr/share/clearwater/clearwater-auto-config-generic/bin/
+clearwater-infrastructure/usr/share/clearwater/infrastructure/install/common /usr/share/clearwater-auto-config/bin/


### PR DESCRIPTION
Ellie,

https://github.com/Metaswitch/sprout/pull/1872 breaks the AIO node, because we don't assume they have SRV records.

This adds the URIs (S-CSCF, I-CSCF and BGCF) to allow the AIO nodes to work again.

I've commonalized a bunch of the duplicated logic between -generic and -aws. 

Thoughts?