### PR TITLE
[Reviewer: Ellie] Add mappings for I-CSCF and BGCF hostnames as well

### DIFF
--- a/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
+++ b/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
@@ -69,7 +69,7 @@ write_config()
   add_section_text \
     /etc/hosts \
     "clearwater-aio" \
-    "$arg_local_ip $public_hostname ${scscf_prefix}.${public_hostname}"
+    "$arg_local_ip $public_hostname ${scscf_prefix}.${public_hostname} ${bgcf_prefix}.${public_hostname} ${icscf_prefix}.${public_hostname}"
 
   service dnsmasq restart
 }


### PR DESCRIPTION
Ellie,

While testing the changes in https://github.com/Metaswitch/clearwater-infrastructure/pull/288, I spotted that the I-CSCF and BGCF sproutlets don't resolve on the AIO nodes.

This is because we only add mappings for the S-CSCF.

This adds mappings for the others. I've tested on a AIO node spun up in Amazon using Chef.
