### PR TITLE
[Reviewer: Adam] Configure Homestead IMPU Stores in auto config

### DIFF
--- a/clearwater-auto-config/etc/clearwater/shared_config
+++ b/clearwater-auto-config/etc/clearwater/shared_config
@@ -9,6 +9,7 @@ chronos_hostname=
 cassandra_hostname=
 sprout_registration_store=
 ralf_session_store=
+homestead_impu_store=
 
 # Email server configuration
 smtp_smarthost=127.0.0.1

--- a/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
+++ b/clearwater-auto-config/usr/share/clearwater-auto-config/bin/init-functions
@@ -53,6 +53,7 @@ write_config()
           s/^hs_hostname=.*$/hs_hostname='$arg_address':8888/g
           s/^hs_provisioning_hostname=.*$/hs_provisioning_hostname='$arg_address':8889/g
           s/^sprout_registration_store=.*$/sprout_registration_store='$arg_address'/g
+          s/^homestead_impu_store=.*$/homestead_impu_store='$arg_address'/g
           s/^upstream_hostname=.*$/upstream_hostname='$arg_upstream_hostname'/g
           s/^scscf_uri=.*/scscf_uri="sip:'$scscf_prefix'.'$arg_public_hostname':'$scscf';transport=TCP"/g
           s/^icscf_uri=.*/icscf_uri="sip:'$icscf_prefix'.'$arg_public_hostname':'$icscf';transport=TCP"/g

--- a/debian/clearwater-auto-config-docker.init.d
+++ b/debian/clearwater-auto-config-docker.init.d
@@ -83,6 +83,7 @@ do_auto_config()
       sprout_registration_store=astaire
       chronos_hostname=chronos
       cassandra_hostname=cassandra
+      homestead_impu_store=astaire
       hs_hostname=homestead:8888
       hs_provisioning_hostname=homestead-prov:8889
       xdms_hostname=homer:7888
@@ -96,6 +97,7 @@ do_auto_config()
       sprout_registration_store=astaire.$ZONE
       chronos_hostname=chronos.$ZONE
       cassandra_hostname=cassandra.$ZONE
+      homestead_impu_store=astaire.$ZONE
       hs_hostname=homestead.$ZONE:8888
       hs_provisioning_hostname=homestead-prov.$ZONE:8889
       xdms_hostname=homer.$ZONE:7888
@@ -112,6 +114,7 @@ do_auto_config()
             s/^hs_provisioning_hostname=.*$/hs_provisioning_hostname='$hs_provisioning_hostname'/g
             s/^upstream_hostname=.*$/upstream_hostname='$upstream_hostname'/g
             s/^ralf_hostname=.*$/ralf_hostname='$ralf_hostname'/g
+            s/^homestead_impu_store=.*$/homestead_impu_store='$homestead_impu_store'/g
             s/^sprout_registration_store=.*$/sprout_registration_store='$sprout_registration_store'/g
             s/^ralf_session_store=.*$/ralf_session_store='$ralf_session_store'/g
             s/^chronos_hostname=.*$/chronos_hostname='$chronos_hostname'/g


### PR DESCRIPTION
Configure `homestead_impu_store` alongside `sprout_registration_store`.