### PR TITLE
[Reviewer: Richard] Use 127.0.0.1 not locahost for proxying requests

### DIFF
--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -225,24 +225,24 @@ view clearwater excluded .1.2.826.0.1.1578918.999
 # Proxy for the different Chronos scalar statistics
 #
 # CALL
-proxy -v2c -c clearwater-internal localhost .1.2.826.0.1.1578918.9.10.5.1.0 .1.2.826.0.1.1578918.998.4.67.65.76.76.2.1
+proxy -v2c -c clearwater-internal 127.0.0.1 .1.2.826.0.1.1578918.9.10.5.1.0 .1.2.826.0.1.1578918.998.4.67.65.76.76.2.1
 # SUB
-proxy -v2c -c clearwater-internal localhost .1.2.826.0.1.1578918.9.10.5.2.0 .1.2.826.0.1.1578918.998.3.83.85.66.2.1
+proxy -v2c -c clearwater-internal 127.0.0.1 .1.2.826.0.1.1578918.9.10.5.2.0 .1.2.826.0.1.1578918.998.3.83.85.66.2.1
 # BIND
-proxy -v2c -c clearwater-internal localhost .1.2.826.0.1.1578918.9.10.5.3.0 .1.2.826.0.1.1578918.998.4.66.73.78.68.2.1
+proxy -v2c -c clearwater-internal 127.0.0.1 .1.2.826.0.1.1578918.9.10.5.3.0 .1.2.826.0.1.1578918.998.4.66.73.78.68.2.1
 # REG
-proxy -v2c -c clearwater-internal localhost .1.2.826.0.1.1578918.9.10.5.4.0 .1.2.826.0.1.1578918.998.3.82.69.71.2.1
+proxy -v2c -c clearwater-internal 127.0.0.1 .1.2.826.0.1.1578918.9.10.5.4.0 .1.2.826.0.1.1578918.998.3.82.69.71.2.1
 
 # Proxy for the different types of Chronos timer
 #
 # CALL
-proxy -v2c -c clearwater-internal localhost .1.2.826.0.1.1578918.9.10.6.1 .1.2.826.0.1.1578918.999.4.67.65.76.76
+proxy -v2c -c clearwater-internal 127.0.0.1 .1.2.826.0.1.1578918.9.10.6.1 .1.2.826.0.1.1578918.999.4.67.65.76.76
 # SUB
-proxy -v2c -c clearwater-internal localhost .1.2.826.0.1.1578918.9.10.7.1 .1.2.826.0.1.1578918.999.3.83.85.66
+proxy -v2c -c clearwater-internal 127.0.0.1 .1.2.826.0.1.1578918.9.10.7.1 .1.2.826.0.1.1578918.999.3.83.85.66
 # BIND
-proxy -v2c -c clearwater-internal localhost .1.2.826.0.1.1578918.9.10.8.1 .1.2.826.0.1.1578918.999.4.66.73.78.68
+proxy -v2c -c clearwater-internal 127.0.0.1 .1.2.826.0.1.1578918.9.10.8.1 .1.2.826.0.1.1578918.999.4.66.73.78.68
 # REG
-proxy -v2c -c clearwater-internal localhost .1.2.826.0.1.1578918.9.10.9.1 .1.2.826.0.1.1578918.999.3.82.69.71
+proxy -v2c -c clearwater-internal 127.0.0.1 .1.2.826.0.1.1578918.9.10.9.1 .1.2.826.0.1.1578918.999.3.82.69.71
 
 # Create an internal community that can access anything but is only usable locally.
 rocommunity clearwater-internal 127.0.0.0/8 -V clearwater-internal


### PR DESCRIPTION
_As discussed_

Use `127.0.0.1` not `localhost` for proxying snmp requests.

If the hostname you're proxying to isn't resolvable at the point snmpd is restarted, the proxying will not work at all, even if the hostname later becomes resolvable.

By using `127.0.0.1` we avoid this.

This is a fix for https://github.com/Metaswitch/clearwater-issues/issues/2406

I've manually tested that this fixes the issue by:

1. making `localhost` unresolvable
2. restarting snmpd
3. making `localhost` resolvable again
4. Attempting to query one of the proxies OIDs: .1.2.826.0.1.1578918.9.10.9.1.2.1, which worked (it didn't before this fix)