### PR TITLE
[Reviewer: Adam] Common script for enabling cassandra

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/utils/cassandra_enabled
+++ b/clearwater-infrastructure/usr/share/clearwater/utils/cassandra_enabled
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# @file cassandra_enabled
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+
+. /etc/clearwater/config
+
+USE_CASSANDRA="N"
+
+for SCRIPT in $(ls -1 /usr/share/clearwater/cassandra/users//* 2>/dev/null)
+do
+  if [ -f "$SCRIPT" ]; then
+    . $SCRIPT
+  fi
+done

--- a/clearwater-infrastructure/usr/share/clearwater/utils/cassandra_enabled
+++ b/clearwater-infrastructure/usr/share/clearwater/utils/cassandra_enabled
@@ -13,7 +13,7 @@
 
 USE_CASSANDRA="N"
 
-for SCRIPT in $(ls -1 /usr/share/clearwater/cassandra/users//* 2>/dev/null)
+for SCRIPT in $(ls -1 /usr/share/clearwater/cassandra/users/* 2>/dev/null)
 do
   if [ -f "$SCRIPT" ]; then
     . $SCRIPT

--- a/clearwater-infrastructure/usr/share/clearwater/utils/cassandra_enabled
+++ b/clearwater-infrastructure/usr/share/clearwater/utils/cassandra_enabled
@@ -9,7 +9,6 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
-
 . /etc/clearwater/config
 
 USE_CASSANDRA="N"

--- a/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
+++ b/clearwater-memcached/usr/share/clearwater/infrastructure/scripts/memcached
@@ -20,17 +20,7 @@ then
   listen_address=$(/usr/share/clearwater/bin/ipv6-to-hostname $local_ip)
 fi
 
-if [ -n "$hs_provisioning_hostname" ]; then
-  USE_CASSANDRA="Y"
-fi
-
-if [ -n "$memento_hostname" ]; then
-  USE_CASSANDRA="Y"
-fi
-
-if [ -n "$xdms_hostname" ]; then
-  USE_CASSANDRA="Y"
-fi
+. /usr/share/clearwater/utils/cassandra_enabled
 
 if [ "$USE_CASSANDRA" == "Y" ];
 then


### PR DESCRIPTION
This adds a common mechanism for allowing packages to enable Cassandra.

Each script in `/usr/share/clearwater/cassandra/users/` can set `USE_CASSANDRA` to `Y` to enable Cassandra. If it does (either based on config, or just always), then Cassandra will be started - as per the related Cassandra change.