### PR TITLE
[Reviewer: Seb] Don't create duplicate IPv6 mapping addresses

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/1hosts
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/1hosts
@@ -17,14 +17,14 @@
 # hostname that maps to the address.
 
 # Remove any entries that have been previously added by this script.
-grep -v ' # added by clearwater-infrastructure 1hosts script' /etc/hosts | grep -v ' # maps to local IPv6 address' > /tmp/hosts.$$
+grep -v '# added by clearwater-infrastructure 1hosts script' /etc/hosts | grep -v ' # maps to local IPv6 address' > /tmp/hosts.$$
 
 # Determine whether the local IP address is an IPv6 address.
 if /usr/share/clearwater/bin/is-address-ipv6 $local_ip
 then
   # Generate the ip6.arpa hostname from the IP address.  Add it to the hosts file.
   hostname=$(/usr/share/clearwater/bin/ipv6-to-hostname $local_ip)
-  echo $local_ip $hostname '# added by clearwater-infrastructure 1hosts script' >> /tmp/hosts.$$
+  echo $local_ip $hostname ' # added by clearwater-infrastructure 1hosts script' >> /tmp/hosts.$$
 fi
 
 # Append the IPv6 localhost.  This is to satisfy RFC6761 section 6.3, namely


### PR DESCRIPTION
Seb,

There's a bug in the `1hosts` script.

Each `clearwater-infrastructure` is restarted, if the node has a local IPv6 address, we will add a mapping to /etc/hosts.

This is because there is no space between the end of address, and the ipv6.arpa address - e.g.

```
fd5f:5d21:845:1422:1::45d 45d.0.0.1.1422.845.5d21.fd5f.ip6.arpa # added by clearwater-infrastructure 1hosts script
```

I've fixed by not checking for a space as part of the grep (so we clean up old entries), and adding a space to the IPv6 entry (to match the others).

I've tested this live on a system and verified it resolves a problem.