### PR TITLE
[Reviewer KH1] Delete the sa file from last month, if any

### DIFF
--- a/clearwater-diags-monitor/etc/cron.d/clearwater-sysstat
+++ b/clearwater-diags-monitor/etc/cron.d/clearwater-sysstat
@@ -1,5 +1,5 @@
 # Get activity reports every minute - this is a finer granularity than the default /etc/cron.d/sysstat
-# Specify -F to force rotation at midnight.
-0 0 * * * root /usr/lib/sysstat/sadc -F 1 1 /var/log/sysstat/clearwater-sa`date +\%d` > /dev/null 2>&1
+# Delete existing file (if any) and specify -F to force rotation at midnight.
+0 0 * * * root rm -f /var/log/sysstat/clearwater-sa`date +\%d`;/usr/lib/sysstat/sadc -F 1 1 /var/log/sysstat/clearwater-sa`date +\%d` > /dev/null 2>&1
 1-59 0 * * * root /usr/lib/sysstat/sadc 1 1 /var/log/sysstat/clearwater-sa`date +\%d` > /dev/null 2>&1
 * 1-23 * * * root /usr/lib/sysstat/sadc 1 1 /var/log/sysstat/clearwater-sa`date +\%d` > /dev/null 2>&1


### PR DESCRIPTION
Hi Krista

Can you review this infrastructure change for me?  The problem I'm fixing is that, on systems that have been deployed for more than a month, the sadc (system diagnostic) output that is written to "/var/log/sysstat/clearwater-sa<day of the month>`" gets appended to the end of the file that was created a month previously.  In other words, the "-F" parameter that Nicole added in https://github.com/Metaswitch/clearwater-infrastructure/pull/162 doesn't seem to have had the intended effect, which was to truncate the sa file and start again (otherwise you get spurious averages in analyses of the sa files that include data form the previous month, and, perhaps more ominously we leak 3MB of diskspace a day)

I've therefore added an explicit delete of the file with the day number at 00:00.  I've given it a live test on our test deployment and can confirm that the day file from last month is deleted and recreated.  I've left the -F in as insurance (it ensures that the file will be truncated if its the wrong format.  Can't think of a case where the rm -f shouldn't take care of it, but doesn't hurt to leave it in).