### PR TITLE
[Reviewer: Richard] Don't delete core file if creating the diags bundle fails

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -768,6 +768,9 @@ do
 
      # Now just rename the current dump dir to the archive name
      (cd $DUMPS_DIR; mv $CURRENT_DUMP_DIR $FINAL_DUMP_ARCHIVE)
+
+     # Also delete the CURRENT_DUMP_ARCHIVE if it exists
+     rm -f $CURRENT_DUMP_ARCHIVE
   fi
 
   # We should have dealt with all the trigger files by now, unless there are

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -738,10 +738,37 @@ do
   # -z  Zip the archive.
   # -f  Name of the archive.
   (cd $DUMPS_DIR; tar -pcz -f $CURRENT_DUMP_ARCHIVE $CURRENT_DUMP)
-  log "Diagnostic archive $CURRENT_DUMP_ARCHIVE created"
-  rm -rf "$CURRENT_DUMP_DIR"
 
-  mv $CURRENT_DUMP_ARCHIVE $FINAL_DUMP_ARCHIVE
+  # Check whether the tar command succeeded
+  ret_code=$?
+  if [ $ret_code == 0 ]; then
+    log "Diagnostic archive $CURRENT_DUMP_ARCHIVE created"
+    rm -rf "$CURRENT_DUMP_DIR"
+    mv $CURRENT_DUMP_ARCHIVE $FINAL_DUMP_ARCHIVE
+  else
+    # We failed to create the archive. The most common cause of this is lack of
+    # disk space.
+    # Given that the only files in the diags bundle which don't exist elsewhere
+    # on the system are the core files, delete everything that's not a core file
+    # in the temp directory, then just rename that to the archive name without
+    # compressing it
+    log "Failed to create diagnostic archive"
+
+    # In a subshell:
+    # - "set -e" so we don't delete files if we fail to cd to the dump dir
+    # - cd to the dump directory
+    # - get a list of all files/directories which don't begin with "core"
+    # - delete them
+    (set -e
+     cd $CURRENT_DUMP_DIR
+     non_core_files=$(ls | grep -v "^core*")
+     for f in $non_core_files; do
+       rm -rf $f
+     done)
+
+     # Now just rename the current dump dir to the archive name
+     (cd $DUMPS_DIR; mv $CURRENT_DUMP_DIR $FINAL_DUMP_ARCHIVE)
+  fi
 
   # We should have dealt with all the trigger files by now, unless there are
   # more that we can deal with.  Delete any that are left over.


### PR DESCRIPTION
This is a fix for: https://github.com/Metaswitch/clearwater-issues/issues/2383

Creating a diags bundle may fail if we run out of disk space. Since we move any core files into a temporary directory then delete the directory when we're done, if we fail to create the diags bundle we lose the core file.

This fixes the issue by checking whether we succeeded in creating the diags archive. If not, we:
 - delete everything in the temporary directory that isn't the core file
    - this is because the most common cause of failing to create the bundle will be disk space issues, and the core file is the most important file which doesn't exist anywhere else (log files and config files all exist elsewhere). By deleting everything else, we make sure we're not taking up more disk space than the core file needs
 - rename the temporary directory to the archive name
    - this means we'll end up with a directory named XXX.tar.gz but it won't actually be a tar file. We do this because if we're out of disk space we're not going to be able to create an actual tar archive, but by renaming the directory we ensure that it doesn't get cleaned up by the rest of the script

I've tested this by:
 - aborting astaire to generate a diags bundle, ensuring that it works in the mainline case
 - changing the script to replace the tar command with one that fails, and verified that we end up with a folder containing only the core file