### PR TITLE
[Reviewer: AJH] Add TwTimer parameter to Diameter config creation script

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/generic_create_diameterconf
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/generic_create_diameterconf
@@ -129,7 +129,7 @@ TLS_Prio = "NORMAL:-VERS-SSL3.0";
 # Limit the number of SCTP streams
 SCTP_streams = 3;
 
-# The delay before a watchdog message is sent
+# The delay between watchdog messages in seconds
 TwTimer = $tw_timer;
 
 # -------- Extensions ---------

--- a/clearwater-infrastructure/usr/share/clearwater/bin/generic_create_diameterconf
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/generic_create_diameterconf
@@ -12,7 +12,9 @@
 # This file creates a freeDiameter config file, and appropriate
 # TLS keys, for either Ralf, Homestead or Cedar.
 
-usage="Usage: generic_create_diameterconf [homestead|ralf|cedar] DIAMETER_IDENTITY DIAMETER_REALM LISTEN_PORT SECURE_LISTEN_PORT INCOMING_CONNECTIONS CHECK_DESTINATION_HOST TW_TIMER where TW_TIMER >= 6"
+usage="Usage: generic_create_diameterconf [homestead|ralf|cedar] DIAMETER_IDENTITY DIAMETER_REALM LISTEN_PORT SECURE_LISTEN_PORT INCOMING_CONNECTIONS CHECK_DESTINATION_HOST TW_TIMER
+\nThe TW_TIMER parameter is the Diameter watchdog message delay in seconds.
+\nIt must be an integer greater than or equal to 6."
 
 name=$1
 identity=$2
@@ -23,11 +25,18 @@ acl_required=$6
 check_dh=$7
 tw_timer=$8
 
-if [[ $# != 8 ]] || [[ $tw_timer -lt 6 ]]
+if [[ $# != 8 ]]
 then
     # Usage message to stderr
-    echo $usage >&2
+    echo -e $usage >&2
     exit 1
+fi
+
+if [[ $tw_timer -lt 6 ]]
+then
+  echo "TW_TIMER is less than 6!" >&2
+  echo -e $usage >&2
+  exit 1
 fi
 
 key_dir=/var/lib/$name

--- a/clearwater-infrastructure/usr/share/clearwater/bin/generic_create_diameterconf
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/generic_create_diameterconf
@@ -12,7 +12,7 @@
 # This file creates a freeDiameter config file, and appropriate
 # TLS keys, for either Ralf, Homestead or Cedar.
 
-usage="Usage: generic_create_diameterconf [homestead|ralf|cedar] DIAMETER_IDENTITY DIAMETER_REALM LISTEN_PORT SECURE_LISTEN_PORT INCOMING_CONNECTIONS CHECK_DESTINATION_HOST"
+usage="Usage: generic_create_diameterconf [homestead|ralf|cedar] DIAMETER_IDENTITY DIAMETER_REALM LISTEN_PORT SECURE_LISTEN_PORT INCOMING_CONNECTIONS CHECK_DESTINATION_HOST TW_TIMER where TW_TIMER >= 6"
 
 name=$1
 identity=$2
@@ -21,8 +21,9 @@ port=$4
 sec_port=$5
 acl_required=$6
 check_dh=$7
+tw_timer=$8
 
-if [[ $# != 7 ]]
+if [[ $# != 8 ]] || [[ $tw_timer -lt 6 ]]
 then
     # Usage message to stderr
     echo $usage >&2
@@ -128,6 +129,8 @@ TLS_Prio = "NORMAL:-VERS-SSL3.0";
 # Limit the number of SCTP streams
 SCTP_streams = 3;
 
+# The delay before a watchdog message is sent
+TwTimer = $tw_timer;
 
 # -------- Extensions ---------
 


### PR DESCRIPTION
Modifies the script used to generate freeDiameter config files to accept an additional parameter - the delay between watchdog messages in seconds. This time must be at least six seconds; the script verifies that this condition is satisfied.

The script has undergone very basic live testing, with more to come.