### PR TITLE
[Reviever: Richard] Compress core files as we write them to disk

### DIFF
--- a/clearwater-diags-monitor/etc/clearwater/diags-monitor/core_pattern
+++ b/clearwater-diags-monitor/etc/clearwater/diags-monitor/core_pattern
@@ -1,1 +1,1 @@
-/var/clearwater-diags-monitor/tmp/core.%e.%t
+|/usr/share/clearwater/bin/compress_core_file %e %t

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -717,13 +717,6 @@ do
     fi
   done
 
-  jj=0
-  while [ $jj -lt $ii ]
-  do
-    core_file=${trigger_files_arr[$jj]}
-    jj=$(( $jj + 1 ))
-    gzip $CURRENT_DUMP_DIR/$core_file
-  done
   #
   # Diags have been collected.  Time to zip up the diags bundle.
   #

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -717,6 +717,19 @@ do
     fi
   done
 
+  jj=0
+  while [ $jj -lt $ii ]
+  do
+    core_file=${trigger_files_arr[$jj]}
+    jj=$(( $jj + 1 ))
+
+    # If the filename doesn't end in ".gz", gzip it
+    if [[ "$core_file" != *.gz ]]; then
+      log "Compressing $core_file"
+      gzip $CURRENT_DUMP_DIR/$core_file
+    fi
+  done
+
   #
   # Diags have been collected.  Time to zip up the diags bundle.
   #

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/compress_core_file
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/compress_core_file
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+process=$1
+time=$2
+
+gzip > /var/clearwater-diags-monitor/tmp/core.${process}.${time}.gz

--- a/clearwater-diags-monitor/usr/share/clearwater/infrastructure/install/clearwater-diags-monitor.postinst
+++ b/clearwater-diags-monitor/usr/share/clearwater/infrastructure/install/clearwater-diags-monitor.postinst
@@ -24,6 +24,9 @@ chmod a+rwx /var/clearwater-diags-monitor/tmp
 mkdir -p /var/clearwater-diags-monitor/dumps
 chmod a+rwx /var/clearwater-diags-monitor/dumps
 
+# Stop the running diags monitor process, if there is one
+service clearwater-diags-monitor stop || /bin/true
+
 # Make sure the monit configuration directory exists, copy our file in and restart monit.
 mkdir -p /etc/monit/conf.d/
 cp /usr/share/clearwater/clearwater-diags-monitor/conf/clearwater-diags-monitor.monit /etc/monit/conf.d/


### PR DESCRIPTION
Core files can be large, and we don't necessarily have much disk space. So this changes our core file pattern to pipe the core file to a script which uses `gzip` to compress them to disk.

(The compression is done by a separate file rather than inline in the core pattern because you pass a program to a core pattern, not a shell command, and we want to use a shell to redirect the gzip output to a file)

I've removed the (now unnecessary) compression of core files in the diags bundle, as they're compressed already.

I've also added a `service clearwater-diags-monitor stop` to the postinst script so that we'll pick up the new core file pattern when the new package is installed.

I've live tested this by sending SIGABRT to sprout and homestead and verifying that the core files are compressed when they're written out, and that the diags monitor correctly waits for them to be fully written before trying to move them (which it did already). I unzipped a core file and loaded it into gdb to confirm that it was useable.