### PR TITLE
[Reviewer: EM] Modify poll-sip script to count 503 response as failure

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/poll-sip
@@ -49,7 +49,7 @@ fi
 
 when_nc_started=$(date --utc  --rfc-3339=ns)
 
-nc -v -C -w $(( $wait_time + 1 )) -q $wait_time $local_ip $port <<EOF 2> /tmp/poll-sip.nc.stderr.$$ | tee /tmp/poll-sip.nc.stdout.$$ | head -1 | egrep -q "^SIP/2.0 (200|503)"
+nc -v -C -w $(( $wait_time + 1 )) -q $wait_time $local_ip $port <<EOF 2> /tmp/poll-sip.nc.stderr.$$ | tee /tmp/poll-sip.nc.stdout.$$ | head -1 | egrep -q "^SIP/2.0 200"
 OPTIONS sip:poll-sip@$sip_ip:$port SIP/2.0
 Via: SIP/2.0/TCP $sip_ip;rport;branch=z9hG4bK-$id
 Max-Forwards: 2


### PR DESCRIPTION
This changes our monit SIP polling to count a SIP 503 Service Unavailable response as a failed rather than successful poll, in line with our changes to Sprout which prioritize such polls during overload.