### PR TITLE
[Reviewer: Seb] Add scripts that allow log level and snmp community names to be changed.

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/set_log_level
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/set_log_level
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright (C) Metaswitch Networks 2016
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+#
+
+# This script sets the log level for the local node.
+. /usr/share/clearwater/infrastructure/install/common
+
+LOG_LEVEL=$1
+if [ "$LOG_LEVEL" == "debug" ]
+then
+  NEW_ENTRY=log_level=5
+elif [ "$LOG_LEVEL" == "normal" ]
+then
+  NEW_ENTRY=
+else
+  echo Error: invalid parameter or no parameter specified.
+  echo ""
+  echo Usage:
+  echo "$0 [normal|debug]"
+  exit 1
+fi
+
+# Touch the file so that we can guarantee that it's present.
+touch /etc/clearwater/user_settings user_settings
+add_section_text /etc/clearwater/user_settings user_settings "$NEW_ENTRY"
+
+echo Log level updated
+cw-restart_node_processes

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/set_snmp_community
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/set_snmp_community
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright (C) Metaswitch Networks 2016
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+#
+
+# This script allows editing of the snmpd configuration file to modify the community and target.
+# It takes two parameters
+COMMUNITY=$1
+TARGET=$2
+
+if [[ $# -ne 2 ]];
+then
+   echo "Error - invalid set of parameters"
+   echo "Usage:"
+   echo "  $0 [community] [target]"
+   echo ""
+   echo "e.g. $(basename $0) clearwater 0.0.0.0/0"
+   echo ""
+   exit 1
+fi
+
+if ! [[ $COMMUNITY =~ ^[0-9A-Za-z_-.]*$ ]];
+then
+  echo Error - invalid characters in community parameter.
+  exit 1
+fi
+
+if ! [[ $TARGET =~ ^[0-9A-Fa-f:./]*$ ]];
+then
+  echo Error - invalid characters in target parameter
+   exit 1
+fi
+
+SNMPD_CONF=/etc/snmp/snmpd.conf
+TMP_FILE=$(mktemp $SNMPD_CONF.XXXXX)
+sed "s#\(rocommunity \).*\( -V clearwater\)#\1$COMMUNITY $TARGET\2#g" $SNMPD_CONF >$TMP_FILE
+mv $TMP_FILE $SNMPD_CONF
+
+echo Configuration updated
+service snmpd reload


### PR DESCRIPTION
As discussed elsewhere:

"Code looks good.

I was expecting the log level script to just take a number, but this is probably actually more helpful for a user setting the log level (I'm assuming that these are the only 2 log levels that we tell people to use in the manuals)."

For the record, the only guidance for log_level is for debug. It doesn't even tell you how to undo the change (although I think that's implicitly, remove the line you added).
