### PR TITLE
[Reviewer: Seb] Fix split DNS signaling configuration checking 

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/config_validation/project_clearwater_options.py
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/config_validation/project_clearwater_options.py
@@ -57,7 +57,7 @@ def get_options():
 
         Option('enum_server', Option.OPTIONAL,
                vlds.run_in_sig_ns(vlds.resolveable_ip_or_domain_name_list_validator)),
-        Option('signaling_dns_server', Option.OPTIONAL, vlds.ip_addr_validator),
+        Option('signaling_dns_server', Option.OPTIONAL, vlds.ip_addr_list_validator),
         Option('remote_cassandra_seeds', Option.OPTIONAL, vlds.ip_addr_validator),
         Option('billing_realm', Option.OPTIONAL,
                vlds.run_in_sig_ns(vlds.diameter_realm_validator)),

--- a/cw_infrastructure/cw_infrastructure/check_config_utilities.py
+++ b/cw_infrastructure/cw_infrastructure/check_config_utilities.py
@@ -107,7 +107,7 @@ def is_domain_resolvable(name, rrtype):
         answers = resolver.query(name, rrtype)
         return len(answers) != 0
 
-    except:
+    except Exception as e:
         return False
 
 

--- a/cw_infrastructure/cw_infrastructure/check_config_utilities.py
+++ b/cw_infrastructure/cw_infrastructure/check_config_utilities.py
@@ -82,11 +82,8 @@ def is_domain_name(value):
 
 def is_resolvable_domain_name(value):
     """Return whether the supplied string is a resolvable domain name"""
-    try:
-        socket.gethostbyname(value)
-        return True
-    except socket.gaierror:
-        return False
+    return (is_domain_resolvable(value, 'A') or
+            is_domain_resolvable(value, 'AAAA'))
 
 
 def is_naptr_resolvable(naptr):

--- a/cw_infrastructure/cw_infrastructure/check_config_utilities.py
+++ b/cw_infrastructure/cw_infrastructure/check_config_utilities.py
@@ -102,7 +102,9 @@ def is_domain_resolvable(name, rrtype):
     """Check whether the given domain has any records of the given type"""
 
     try:
-        answers = dns.resolver.query(name, rrtype)
+        resolver = dns.resolver.get_default_resolver()
+        resolver.timeout = 2
+        answers = resolver.query(name, rrtype)
         return len(answers) != 0
 
     except:

--- a/cw_infrastructure/cw_infrastructure/validators.py
+++ b/cw_infrastructure/cw_infrastructure/validators.py
@@ -202,7 +202,7 @@ def sip_uri_validator(name, value):
             return ERROR
 
     elif transport:
-        srv = '_sip._{}.{}'.format(params['transport'], host)
+        srv = '_sip._{}.{}'.format(params['transport'].lower(), host)
 
         if utils.is_srv_resolvable(srv):
             return OK


### PR DESCRIPTION
Seb,

I've tested this on the QA system.

There's bunch of problems but the net result is that checking DNS records while using split namespaces is broken.

The main reason is because we passed in `signaling_dns_server` directly, which could be a list of IP addresses instead of a single IP address, which would cause DNS resolution to fail.

That's also some other bugs, detailed in the commit messages.