### PR TITLE
[Reviewer: Seb] Preserve clearwater-check-config --show

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
@@ -15,6 +15,12 @@ LOCAL_CONFIG=$CONFIG_DIR/local_config
 USER_SETTINGS=$CONFIG_DIR/user_settings
 CLEARWATER_CONFIG=$CONFIG_DIR/config
 
+# Compatibility for when show-config didn't exist
+if [ "$1" --eq "--show" ];
+then
+  exec /usr/share/clearwater/bin/clearwater-show-config "${@:2}"
+fi
+
 if [ -n "$1" ];
 then
   SHARED_CONFIG="$1"


### PR DESCRIPTION
Seb,

Previous versions of `clearwater-check-config` have allowed a `--show` option which allows the current config to be shown.

This function is now implemented by `clearwater-show-config`, but we should preserve the command line argument.

`"${@:2}"` passes any remaining arguments to the new process in the correct fashion (including handling arguments with spaces in them, somewhat surprisingly).