### PR TITLE
[Reviewer: RobD] Fix the set_snmp_community command

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
@@ -21,10 +21,10 @@ then
    echo ""
    echo " [community] is the SNMP community name"
    echo " [target] is a hostname, IPv4 address or subnet (represented "
-   echo "either as IP/MASK or IP/BITS)."
+   echo "either as IP/MASK or IP/BITS) where IP is the network prefix"
    echo ""
-   echo "e.g. cw-set_snmp_community clearwater 1.2.3.4/255.255.0.0"
-   echo " or  cw-set_snmp_community clearwater 1.2.3.4/16"
+   echo "e.g. cw-set_snmp_community clearwater 1.2.0.0/255.255.0.0"
+   echo " or  cw-set_snmp_community clearwater 1.2.0.0/16"
    echo ""
    exit 1
 fi
@@ -46,8 +46,8 @@ fi
 
 SNMPD_CONF=/etc/snmp/snmpd.conf
 TMP_FILE=$(mktemp $SNMPD_CONF.XXXXX)
-sed "s#\(rocommunity \).*\( -V clearwater$\)#\1$COMMUNITY $TARGET\2#g" $SNMPD_CONF >$TMP_FILE
-mv $TMP_FILE $SNMPD_CONF
+sed "s#\(rocommunity \).*\( -V clearwater$\)#\1$COMMUNITY $TARGET\2#g" "$SNMPD_CONF" >"$TMP_FILE"
+mv "$TMP_FILE" "$SNMPD_CONF"
 
 echo Configuration updated
 service snmpd restart

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
@@ -30,7 +30,7 @@ then
 fi
 
 # Community strings can be any combination of letters, numbers dashes, underscores or dots.
-if ! [[ $COMMUNITY =~ ^[0-9A-Za-z\\-_.]*$ ]];
+if ! [[ $COMMUNITY =~ ^[0-9A-Za-z_.\\-]*$ ]];
 then
   echo Error - invalid characters in community parameter.
   exit 1

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
@@ -30,7 +30,7 @@ then
 fi
 
 # Community strings can be any combination of letters, numbers dashes, underscores or dots.
-if ! [[ $COMMUNITY =~ ^[0-9A-Za-z_.\\-]*$ ]];
+if ! [[ $COMMUNITY =~ ^[0-9A-Za-z_.\-]*$ ]];
 then
   echo Error - invalid characters in community parameter.
   exit 1
@@ -38,7 +38,7 @@ fi
 
 # Check valid IPv4 address/MASK (dots, numbers and forward slash), or hostname
 # (alphanumeric, dots or dashes)
-if ! [[ $TARGET =~ ^[0-9A-Za-z/.\\-]*$ ]];
+if ! [[ $TARGET =~ ^[0-9A-Za-z/.\-]*$ ]];
 then
   echo Error - invalid characters in target parameter
    exit 1

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
@@ -29,13 +29,16 @@ then
    exit 1
 fi
 
-if ! [[ $COMMUNITY =~ ^[0-9A-Za-z_-.]*$ ]];
+# Community strings can be any combination of letters, numbers dashes, underscores or dots.
+if ! [[ $COMMUNITY =~ ^[0-9A-Za-z\\-_.]*$ ]];
 then
   echo Error - invalid characters in community parameter.
   exit 1
 fi
 
-if ! [[ $TARGET =~ ^[0-9A-Za-z./\-]*$ ]];
+# Check valid IPv4 address/MASK (dots, numbers and forward slash), or hostname
+# (alphanumeric, dots or dashes)
+if ! [[ $TARGET =~ ^[0-9A-Za-z/.\\-]*$ ]];
 then
   echo Error - invalid characters in target parameter
    exit 1

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
@@ -46,8 +46,8 @@ fi
 
 SNMPD_CONF=/etc/snmp/snmpd.conf
 TMP_FILE=$(mktemp $SNMPD_CONF.XXXXX)
-sed "s#\(rocommunity \).*\( -V clearwater$\)#\1$COMMUNITY $TARGET\2#g" "$SNMPD_CONF" >"$TMP_FILE"
-mv "$TMP_FILE" "$SNMPD_CONF"
+sed "s#\(rocommunity \).*\( -V clearwater$\)#\1$COMMUNITY $TARGET\2#g" $SNMPD_CONF >"$TMP_FILE"
+mv "$TMP_FILE" $SNMPD_CONF
 
 echo Configuration updated
 service snmpd restart

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/bin/set_snmp_community
@@ -47,4 +47,4 @@ sed "s#\(rocommunity \).*\( -V clearwater$\)#\1$COMMUNITY $TARGET\2#g" $SNMPD_CO
 mv $TMP_FILE $SNMPD_CONF
 
 echo Configuration updated
-service snmpd reload
+service snmpd restart


### PR DESCRIPTION

Can you review please - I've run a bunch of tests with different IP addresses to confirm it works. I also ran with a variety of bad community names and confirmed that swapping community names worked properly


Tested:
(valid connections)
cw-set_snmp_community clearwater-test 172.18.112.60 (i.e. exact address)
cw-set_snmp_community clearwater-test 172.18.112.60/32 (i.e. exact address with irrelevant subnet)
cw-set_snmp_community clearwater-test 172.18.112.60/255.255.255.255 (i.e. exact address with irrelevant subnet)
cw-set_snmp_community clearwater-test 172.18.112.60/255.255.255.252 (i.e. 60->63)
cw-set_snmp_community clearwater-test 172.18.112.60/30 (i.e. 60->63)
cw-set_snmp_community clearwater-test 172.18.112.56/29 (i.e. 56->63)
cw-set_snmp_community clearwater-test 0.0.0.0/0 (i.e. everything and the default)

(deliberate failures)
cw-set_snmp_community clearwater-test 172.18.112.61 (wrong address)
cw-set_snmp_community clearwater-test 172.18.112.56/30 (i.e. 56->59 so doesn’t work)
cw-set_snmp_community clearwater-test 172.18.112.56/255.255.255.252 (i.e. 56->59 so doesn’t work)

(bad communities)
cw-set_snmp_community clearwater-test+ 172.18.112.60
cw-set_snmp_community clearwater-test, 172.18.112.60
cw-set_snmp_community clearwater-test/ 172.18.112.60
cw-set_snmp_community clearwater-test= 172.18.112.60
cw-set_snmp_community clearwater-test* 172.18.112.60

