### PR TITLE
[Reviewer: Ellie] Don't use the singleton Context - it's not multithread-safe

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/alarms.py
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/alarms.py
@@ -23,7 +23,7 @@ from subprocess import call
 
 def sendrequest(request):
   try:
-    context = zmq.Context.instance()
+    context = zmq.Context()
 
     client = context.socket(zmq.REQ)
     client.connect("ipc:///var/run/clearwater/alarms")


### PR DESCRIPTION
We use `zmq.Context.instance()` to get a 0MQ context, but this isn't safe for multithreading - two threads could use it at the same time and (possibly worse), one could terminate it while the other is using it.

@eleanor-merry, please can you review?

I've live-tested with the following stress script:

```python
import imp
from threading import Thread
from time import sleep

def foo(ii):
   # Do some throw-away work to tweak scheduling
   for jj in range(0, 100000):
       kk = jj * 2

   # Import alarms
   file, pathname, description = imp.find_module("alarms", ["/usr/share/clearwater/bin"])
   mod = imp.load_module("alarms", file, pathname, description)
   sendrequest = mod.sendrequest

   # Send, send, send!
   while True:
      sendrequest(["issue-alarm", "homestead", "%d" % (ii,)])
      runnings[ii] = True

# Create the threads
threads = [Thread(target=foo, args=(ii,)) for ii in range(100)]
runnings = [False for thread in threads]
for thread in threads:
   thread.start()

# Iterate, checking that our threads are still unblocked
cycle = 0
while True:
   sleep(1)
   if all(runnings):
       print("Cycle %d OK" % (cycle,))
   else:
       print("Cycle %d failed: %s" % (cycle, runnings))
   runnings = [False for thread in threads]
   cycle = cycle + 1
```