### PR TITLE
Gather logs directory as a tar.gz

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -74,6 +74,29 @@ copy_to_dump()
   fi
 }
 
+# Copy files and directories to the dump as a tar.gz.
+#
+# For example the directory /var/log/sprout would be copied to
+# <dumpdir>/var/log/sprout.tar.gz
+#
+# Params:
+#   $1 - The objects to copy.
+copy_to_dump_as_tar_gz()
+{
+  src=$(realpath $1)
+  src_dir=$(dirname $src)
+  src_name=$(basename $src)
+
+  if [[ $src && $src_dir && $src_name ]]
+  then
+    dst=$CURRENT_DUMP_DIR/root${src}.tar.gz
+    mkdir -p $(dirname $dst)
+    tar -C $src_dir -zcf $dst $src_name
+  else
+    log "$1 not present in deployment"
+  fi
+}
+
 # Move files and directories to the dump preserving the full path.
 # Use this when the file is very large or is used to trigger a diags
 # collection (so we don't repeatedly trigger on the same file).
@@ -552,7 +575,7 @@ do
   #
 
   # Log files.
-  copy_to_dump '/var/log'
+  copy_to_dump_as_tar_gz '/var/log'
 
   # PID files
   copy_to_dump '/var/run'


### PR DESCRIPTION
This avoids using up too much space temporarily when copying logs into the diags dump. This is useful because if you have 1GB of free space, and 5GB of uncompressed logs that would compress down to 100MB, we are now able to capture those logs 😄 

I've tested this by spinning up a deployment with chef, running `cw-gather_diags` and checking the logs are correctly gathered. As a bonus, the `*_current.txt` symlinks now work in the diags dump 😃 