### PR TITLE
Allows a suggested parameter to be missing from shared_config and still pass the validation

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
@@ -173,8 +173,8 @@ check_option_locations || rc=1
 # Check that the config is semantically correct (e.g. required options are
 # present, they are correctly formatted, etc).
 check_config_values
-# return of 4 shows a suggested parameter but not a required one, so the
-# validation should still pass but will print a warning to screen.
+# A return value 4 shows a suggested parameter is missing but not a required
+# one, so the validation will still pass but will print the warning to screen.
 [[ $? == 0 || $? == 4 ]] || rc=1
 
 # Print out a soothing message to the user if all the checks passed.

--- a/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
@@ -172,7 +172,10 @@ check_option_locations || rc=1
 
 # Check that the config is semantically correct (e.g. required options are
 # present, they are correctly formatted, etc).
-check_config_values || rc=1
+check_config_values
+# return of 4 shows a suggested parameter but not a required one, so the
+# validation should still pass but will print a warning to screen.
+[[ $? == 0 || $? == 4 ]] || rc=1
 
 # Print out a soothing message to the user if all the checks passed.
 if [[ "$rc" -eq 0 ]]; then


### PR DESCRIPTION
This change means that suggested parameters being missing no longer fail the validation for shared config.

I have live tested this by patching it onto a node and testing it works as expected. This was tested individually and alongside changes to https://github.com/Metaswitch/clearwater-etcd/pull/547