### PR TITLE
Adjust check_config.py to return the highest value

### DIFF
--- a/cw_infrastructure/cw_infrastructure/check_config.py
+++ b/cw_infrastructure/cw_infrastructure/check_config.py
@@ -29,18 +29,16 @@ def check_config_options(options):
             if option.validator:
                 code = option.validator(option.name, value)
 
-                # The validator is responsible for printing an error message.
-                if code > status:
-                    status = code
-
         else:
             # The option is not present, which is an error if it's mandatory.
             if option.mandatory():
                 error(option.name, 'option is mandatory but not present')
-                status = ERROR
+                code = ERROR
             elif option.suggested():
                 warning(option.name, 'option is not configured')
-                status = WARNING
+                code = WARNING
+        # A higher value indicates a worse error.
+        status = max(status, code)
     return status
 
 


### PR DESCRIPTION
This is to allow the worst error code to be returned rather than the newest, this was causing a bug when two options don't exist and the mandatory was before the warning level one.

I have live tested this a bit and it seems to avoid the previous issue.