### PR TITLE
[Reviewer: MIRW] More detailed ps diagnostics

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -347,7 +347,7 @@ get_os_info()
 # Get information about running processes.
 get_process_info()
 {
-  ps -eaf > $CURRENT_DUMP_DIR/ps-eaf.txt
+  ps axo user,pid,pcpu,pmem,vsz,rss,tty,stat,lstart,time,command > $CURRENT_DUMP_DIR/ps_axo.txt
 }
 
 


### PR DESCRIPTION
Hi Matt, could you please review this fix?

This is a simple enhancement to the diags for the 'ps' command. The issue was that the output of the original 'ps -eaf' command was not detailed enough (e.g. did not include memory information). I have replaced it with essentially 'ps aux' with more granularity in the timestamps. 

Here is a sample output from the clearwater-diag-monitor diags on an SPN node:

```
USER       PID %CPU %MEM   VSZ      RSS   TT   STAT  STARTED                             TIME       COMMAND
root         1      0.0      0.0        33480  2476  ?     Ss      Mon Sep 18 12:24:01 2017 00:00:01  /sbin/init
root         2      0.0      0.0        0          0        ?     S       Mon Sep 18 12:24:01 2017 00:00:00  [kthreadd]
```

(* sorry for the formatting, view under edit mode to see correctly)