### PR TITLE
[Reviewer: RJW2] Fixed 'clearwater-check-config' command w.r.t. passing the '--show' option

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
@@ -15,15 +15,13 @@ LOCAL_CONFIG=$CONFIG_DIR/local_config
 USER_SETTINGS=$CONFIG_DIR/user_settings
 CLEARWATER_CONFIG=$CONFIG_DIR/config
 
-# Display the config
+rc_show_config=0
 if [ "$1" == "--show" ];
-then
-  /usr/share/clearwater/bin/clearwater-show-config "${@:2}"
-  if [ $? -ne 0 ]; then
-    exit $?
-  fi
+then # Display the config
+  /usr/share/clearwater/bin/clearwater-show-config
+  rc_show_config = $?
   echo
-  exec /usr/share/clearwater/bin/clearwater-check-config "${@:2}"
+  shift
 fi
 
 if [ -n "$1" ];
@@ -185,6 +183,9 @@ check_config_values
 # Print out a soothing message to the user if all the checks passed.
 if [[ "$rc" -eq 0 ]]; then
   echo "All config checks passed"
+  # We output the rc returned by clearwater-show-config if clearwater-check-config
+  # returned no errors
+  exit $rc_show_config 
 fi
 
 exit $rc

--- a/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
@@ -15,10 +15,12 @@ LOCAL_CONFIG=$CONFIG_DIR/local_config
 USER_SETTINGS=$CONFIG_DIR/user_settings
 CLEARWATER_CONFIG=$CONFIG_DIR/config
 
-# Compatibility for when show-config didn't exist
+# Display the config
 if [ "$1" == "--show" ];
 then
-  exec /usr/share/clearwater/bin/clearwater-show-config "${@:2}"
+  /usr/share/clearwater/bin/clearwater-show-config "${@:2}"
+  echo
+  exec /usr/share/clearwater/bin/clearwater-check-config "${@:2}"
 fi
 
 if [ -n "$1" ];

--- a/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/clearwater-check-config
@@ -19,6 +19,9 @@ CLEARWATER_CONFIG=$CONFIG_DIR/config
 if [ "$1" == "--show" ];
 then
   /usr/share/clearwater/bin/clearwater-show-config "${@:2}"
+  if [ $? -ne 0 ]; then
+    exit $?
+  fi
   echo
   exec /usr/share/clearwater/bin/clearwater-check-config "${@:2}"
 fi


### PR DESCRIPTION
Hi Richard, 

Here is a fix to a change I believe you made earlier. Would you mind reviewing it?

Running the command "clearwater-check-config --show" now outputs the contents of the config files to the console AND checks the config for errors.

I have tested the fix by patching one of our l3-cc3 test boxes.