### PR TITLE
[Reviewer: EM] Added directories to diags dump

### DIFF
--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -598,8 +598,6 @@ do
   get_cw_package_checksums
   get_package_info
 
-  # Monit related files.
-
   # Networking information.
   #
   # Connectivity between nodes is handled in per-node hooks as security groups

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -283,6 +283,7 @@ check_connectivity_to_domain()
 get_network_info()
 {
   copy_to_dump "/etc/hosts"
+  copy_to_dump "/etc/netns"
 
   # For some reason, redirecting ifconfig to file doesn't work on CentOS, so we
   # pipe through tee instead.  We do the same below.
@@ -596,6 +597,9 @@ do
   get_cw_package_info
   get_cw_package_checksums
   get_package_info
+
+  # Monit related files.
+  copy_to_dump '/var/lib/monit'
 
   # Networking information.
   #

--- a/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
+++ b/clearwater-diags-monitor/usr/share/clearwater/bin/clearwater_diags_monitor
@@ -599,7 +599,6 @@ do
   get_package_info
 
   # Monit related files.
-  copy_to_dump '/var/lib/monit'
 
   # Networking information.
   #


### PR DESCRIPTION
Hi Ellie, would you mind reviewing this please?

Here is another simple fix to the clearwater_diags_monitor. This fix add the following directories to the diags dump gathered by running cw-gather_diags.

-  ./monit_diags/root/var/lib/monit
-  .root/etc/netns

I tested the fix by running the command and checking for the relevant directories under the dump.

The monit-related script lives under clearwater-monit. Here is the related PR https://github.com/Metaswitch/clearwater-monit/pull/62.