### PR TITLE
[Reviewer: Adam] Check if cassandra_hostname only if using HS-Prov

### DIFF
--- a/cw_infrastructure/cw_infrastructure/clearwater_options.py
+++ b/cw_infrastructure/cw_infrastructure/clearwater_options.py
@@ -76,11 +76,20 @@ def get_options():
                vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_with_port_validator)),
         Option('chronos_hostname', Option.OPTIONAL,
                vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_validator)),
-        Option('cassandra_hostname', Option.OPTIONAL,
-                vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_validator)),
         Option('xdms_hostname', Option.OPTIONAL,
                vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_with_port_validator))
     ]
+
+    if os.environ.get('hs_provisioning_hostname') is not None:
+        # If Homestead Prov is configured, a valid Cassandra hostname must also
+        # be configured
+        options.append(
+            Option(
+                'cassandra_hostname',
+                Option.MANDATORY,
+                vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_validator))
+        )
+
     return options
 
 


### PR DESCRIPTION
Adam,

As discussed this is a slight tweak to the change you just made to Clearwater validators.

If a deployment is not using Homestead Prov, it may have a configured Cassandra hostname, but that hostname isn't necessarily valid, and isn't required to be so.

As such, we disable checking the Cassandra hostname if Homestead Prov is not configured (i.e. `hs_provisioning_hostname` is not configured).