### PR TITLE
[Reviewer: Seb] Use pip to install buildout instead of setuptools

### DIFF
--- a/clearwater-infrastructure/PyZMQ/Makefile
+++ b/clearwater-infrastructure/PyZMQ/Makefile
@@ -7,23 +7,26 @@ X86_64_ONLY=0
 .DEFAULT_GOAL = build
 
 .PHONY: build
-build: bin/buildout buildout.cfg
+
+PIP_VERSION := 9.0.1
+BUILDOUT_VERSION := 2.11.0
+
+MARKER_FILE := ${ENV_DIR}/.pip_${PIP_VERSION}_buildout_${BUILDOUT_VERSION}
+
+build: ${MARKER_FILE} buildout.cfg
 ifeq (${X86_64_ONLY},1)
-	ARCHFLAGS="-arch x86_64" ./bin/buildout -N
+	ARCHFLAGS="-arch x86_64" ${ENV_DIR}/bin/buildout -N
 else
-	ARCHFLAGS="-arch i386 -arch x86_64" ./bin/buildout -N
+	ARCHFLAGS="-arch i386 -arch x86_64" ${ENV_DIR}/bin/buildout -N
 endif
 
-bin/buildout: ${ENV_DIR}/bin/python
+${MARKER_FILE}:
+	rm -rf _env
+	virtualenv --no-site-packages --python=${PYTHON_BIN} ${ENV_DIR}
 	mkdir -p .buildout_downloads/dist
-	${ENV_DIR}/bin/easy_install "setuptools==24"
-	${ENV_DIR}/bin/easy_install distribute
-	${ENV_DIR}/bin/easy_install zc.buildout
-	mkdir -p bin/
-	ln -s ${ENV_DIR}/bin/buildout bin/
-
-${ENV_DIR}/bin/python:
-	virtualenv --no-site-packages --setuptools --python=${PYTHON_BIN} ${ENV_DIR}
+	${ENV_DIR}/bin/pip install --upgrade "pip==${PIP_VERSION}"
+	${ENV_DIR}/bin/pip install "zc.buildout==${BUILDOUT_VERSION}"
+	touch $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Seb,

clearwater-infrastructure bundles a version of PyZMQ newer than is available on Ubuntu Trusty by default - specifically it bundles PyZMQ 16.02 (https://github.com/Metaswitch/clearwater-infrastructure/commit/39425a15c8908ef84a15076ca0659496126e0226) instead of 14.0.1 which is available in Ubuntu Trusty (see https://packages.ubuntu.com/trusty/python-zmq).

Currently we use setuptools to install this, but we do this in an odd way (installing it in the virtualenv, then reinstalling it in the virtualenv, then installing distribute, the installing buildout). Finally, we link the buildout installed in the venv into the bin folder (for extremely poorly defined reasons) and then run it via the symlink.

This is fairly horrible, and is causing spurious failures of the following form, which all rather miserable:

```
/home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/bin/easy_install "setuptools==24"
Searching for setuptools==24
Reading https://pypi.python.org/simple/setuptools/
Downloading https://pypi.python.org/packages/9f/e7/0dad3c2362a4b0ef0a432d07d5b8dab433a1b3cff54e55045b36f05153c2/setuptools-24.0.0-py2.py3-none-any.whl#md5=4b5ae10b4b7f2db6d6425d700be0b93e
Best match: setuptools 24.0.0
Processing setuptools-24.0.0-py2.py3-none-any.whl
Installing setuptools-24.0.0-py2.py3-none-any.whl to /home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/lib/python2.7/site-packages
writing requirements to /home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/lib/python2.7/site-packages/setuptools-24.0.0-py2.7.egg/EGG-INFO/requires.txt
Adding setuptools 24.0.0 to easy-install.pth file
Installing easy_install-3.5 script to /home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/bin
Installing easy_install script to /home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/bin

Installed /home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/lib/python2.7/site-packages/setuptools-24.0.0-py2.7.egg
Processing dependencies for setuptools==24
Finished processing dependencies for setuptools==24
/home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/bin/easy_install distribute
Traceback (most recent call last):
  File "/home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/bin/easy_install", line 11, in <module>
    load_entry_point('setuptools==24.0.0', 'console_scripts', 'easy_install')()
  File "/home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 572, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2755, in load_entry_point
    return ep.load()
  File "/home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2408, in load
    return self.resolve()
  File "/home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2414, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/lib/python2.7/site-packages/setuptools-24.0.0-py2.7.egg/setuptools/command/easy_install.py", line 51, in <module>
    from setuptools.archive_util import unpack_archive
  File "/home/user/src/clearwater-infrastructure/clearwater-infrastructure/PyZMQ/_env/lib/python2.7/site-packages/setuptools-24.0.0-py2.7.egg/setuptools/archive_util.py", line 15, in <module>
    from pkg_resources import ensure_directory, ContextualZipFile
ImportError: cannot import name ContextualZipFile
```

Instead, we could just use pip and buildout, using a marker file, and then use the buildout installed in the venv directly. So I've done that. This also speeds up the build as we don't rebuild quite so much quite so often.

I did quickly look at our alternatives entirely, and came up with the following alternative:

- Stop doing any of this madness
- Instead, take the following and stick them in http://repo.cw-ngv.com
  - From Bionic (Ubuntu 18.04):
     - python-zmq_16.0.2-2build2_amd64.deb
  - From Xenial (Ubuntu 16.04):
     - libzmq5_4.1.4-7_amd64.deb
     - libsodium18_1.0.8-5_amd64.deb
     - libstdc++6_5.4.0-6ubuntu1~16.04.4_amd64.deb
     - gcc-5-base_5.4.0-6ubuntu1~16.04.4_amd64.deb
- Change the control file to depend on python-zmq>=16.02.

That's a little scary (as we would be installing a different copy of `libstdc++`) but a quick install seemed to work.

Thoughts?