### PR TITLE
[Reviewer: Richard] Expose file descriptor stats in Clearwater

### DIFF
--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -263,4 +263,3 @@ dontLogTCPWrappersConnects 1
 
 # File descriptor MIB handling
 pass .1.2.826.0.1.1578918.17.1 /usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
-

--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -99,10 +99,10 @@ proc  sendmail 10 1
 #  Disk Monitoring
 #
 #  Only monitor / and /var/log which are the two disks likely to cause service issues.
-#  We mark the threshold as 10% free here but expect customers to monitor these using
+#  We mark the threshold as 20% free here but expect customers to monitor these using
 #  dskPercent.
-disk       /         10%
-disk       /var/log  10%
+disk       /         20%
+disk       /var/log  20%
 
 #  Walk the UCD-SNMP-MIB::dskTable to see the resulting output
 #  Note that this table will be empty if there are no "disk" entries in the snmpd.conf file
@@ -262,5 +262,5 @@ dlmod chronos_handler /usr/lib/clearwater/chronos_handler.so
 dontLogTCPWrappersConnects 1
 
 # File descriptor MIB handling
-pass .1.2.826.0.1.1578918.17.1 /bin/bash /usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
+pass .1.2.826.0.1.1578918.17.1 /usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
 

--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -261,5 +261,5 @@ dlmod chronos_handler /usr/lib/clearwater/chronos_handler.so
 dontLogTCPWrappersConnects 1
 
 # File descriptor MIB handling
-pass .1.2.826.0.1.1578918.17.1 /bin/bash
+pass .1.2.826.0.1.1578918.17.1 /bin/bash /usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
 

--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -259,3 +259,7 @@ dlmod chronos_handler /usr/lib/clearwater/chronos_handler.so
 # Don't log on successful connections - allowing this log means that a log is
 # made to syslog on every stats query, which is too spammy
 dontLogTCPWrappersConnects 1
+
+# File descriptor MIB handling
+pass .1.2.826.0.1.1578918.17.1 /bin/bash
+

--- a/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
+++ b/clearwater-snmpd/etc/snmp/snmpd.conf.clearwater-snmpd
@@ -98,10 +98,11 @@ proc  sendmail 10 1
 #
 #  Disk Monitoring
 #
-                               # 10MBs required on root disk, 5% free on /var, 10% free on all other disks
-disk       /     10000
-disk       /var  5%
-includeAllDisks  10%
+#  Only monitor / and /var/log which are the two disks likely to cause service issues.
+#  We mark the threshold as 10% free here but expect customers to monitor these using
+#  dskPercent.
+disk       /         10%
+disk       /var/log  10%
 
 #  Walk the UCD-SNMP-MIB::dskTable to see the resulting output
 #  Note that this table will be empty if there are no "disk" entries in the snmpd.conf file

--- a/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
+++ b/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright (C) 2018  Metaswitch Networks Ltd
+# Handles SNMP requests offloaded by snmpd for the file descriptor OIDs
+oid_prefix=.1.2.826.0.1.1578918.17.1
+flag=$1
+oid_req=$2
+
+if [ "$1" = "-n" ]; then
+  # If it's a get next, work out what the next matching OID is.
+  case "$oid_req" in
+    $oid_prefix | $oid_prefix.0 | $oid_prefix.0.* | $oid_prefix.1)
+      oid_req=$oid_prefix.1.0;;
+
+    $oid_prefix.1.* | $oid_prefix.2 | $oid_prefix.2.0)
+      oid_req=$oid_prefix.2.0;;
+
+    $oid_prefix.2.* | $oid_prefix.3 | $oid_prefix.3.0)
+      oid_req=$oid_prefix.3.0;;
+
+    $)
+      # No more entries - just return without text and it will be handled by snmpd.
+      exit 0;;
+  esac
+elif [ "$1" = "-g" ]; then
+  # If it's an exact get, ensure that it matches one of our valid OIDs.
+  case "$oid_req" in
+    $oid_prefix.1.0 | $oid_prefix.2.0 | $oid_prefix.3.0)
+      # No matching entry - just return without text and it will be handled by snmpd.
+    *) exit 0;;
+  esac
+else
+  # It's a set request - just return unwriteable
+  echo not-writable
+  exit 0
+fi
+
+# Now that we know we've got something to return, pull out the file descriptor
+# stats and then work out which particular one to return.
+# The syntax is three lines of return:
+#  <oid>
+#  <type>
+#  <value>
+read fd_cur fd_ignore fd_max < /proc/sys/fs/file-nr >>/tmp/kaf.txt 2>&1
+
+echo $oid_req
+echo integer
+
+case "$oid_req" in
+  $oid_prefix.1.0)
+    echo $fd_cur;;
+  $oid_prefix.2.0)
+    echo $fd_max;;
+  $oid_prefix.3.0)
+    fd_perc=$((($fd_cur*100 + $fd_max/2)/$fd_max));
+    echo $fd_perc;;
+  *)
+    exit 0;;
+esac
+exit 0
+
+

--- a/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
+++ b/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
@@ -2,7 +2,6 @@
 # Copyright (C) 2018  Metaswitch Networks Ltd
 # Handles SNMP requests offloaded by snmpd for the file descriptor OIDs
 oid_prefix=.1.2.826.0.1.1578918.17.1
-flag=$1
 oid_req=$2
 
 if [ "$1" = "-n" ]; then

--- a/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
+++ b/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
@@ -1,11 +1,34 @@
 #!/bin/bash
-# Copyright (C) 2018  Metaswitch Networks Ltd
+#
+# Copyright (C) Metaswitch Networks 2018
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+#
+# Called by snmpd to offload requests for the file descriptor OIDs.
+# Syntax:
+# snmp_fd_handler [-n|-g|-s] [oid]
+#   -g - perform a get on the OID
+#   -n - perform a getnext on the OID
+#   -s - perform a set on the OID (rejected by this script)
+#
 # Handles SNMP requests offloaded by snmpd for the file descriptor OIDs
+# Handles three different types of request - set, gets and get nexts and
+# returns the appropriate stat based on the contents of proc's file-nr.
+#
+# The three OIDs this file returns are:
+# oid_prefix.1 = current allocated file descriptors
+# oid_prefix.2 = maximum number of file descriptors
+# oid_prefix.3 = percentage of max fds currently allocated
 oid_prefix=.1.2.826.0.1.1578918.17.1
 oid_req=$2
 
+# Work out which form of request it is so that we can determine the type of the
+# response (which is handled at the end of the script)
 if [ "$1" = "-n" ]; then
-  # If it's a get next, work out what the next matching OID is.
+  # It's a get next so work out what the next matching OID is.
   case "$oid_req" in
     $oid_prefix | $oid_prefix.0 | $oid_prefix.0.* | $oid_prefix.1)
       oid_req=$oid_prefix.1.0;;
@@ -16,15 +39,16 @@ if [ "$1" = "-n" ]; then
     $oid_prefix.2.* | $oid_prefix.3 | $oid_prefix.3.0)
       oid_req=$oid_prefix.3.0;;
 
-    $)
+    *)
       # No more entries - just return without text and it will be handled by snmpd.
       exit 0;;
   esac
 elif [ "$1" = "-g" ]; then
-  # If it's an exact get, ensure that it matches one of our valid OIDs.
+  # It's an exact get so ensure that it matches one of our valid OIDs.
   case "$oid_req" in
     $oid_prefix.1.0 | $oid_prefix.2.0 | $oid_prefix.3.0)
       # No matching entry - just return without text and it will be handled by snmpd.
+      ;;
     *) exit 0;;
   esac
 else
@@ -35,12 +59,14 @@ fi
 
 # Now that we know what we're meant to return, pull out the file descriptor
 # stats from file-nr and return the corresponding value.
-# The return syntax is three lines containing:
+# file-nr consists of three values, the first and last of which are the
+# current and max file descriptors.
+read fd_cur fd_ignore fd_max < /proc/sys/fs/file-nr
+
+# The return syntax for snmpd's call is three lines containing:
 #  <oid>
 #  <type>
 #  <value>
-read fd_cur fd_ignore fd_max < /proc/sys/fs/file-nr >>/tmp/kaf.txt 2>&1
-
 echo $oid_req
 echo integer
 
@@ -50,11 +76,11 @@ case "$oid_req" in
   $oid_prefix.2.0)
     echo $fd_max;;
   $oid_prefix.3.0)
+    # Work out the percentage of file descriptors currently in use. Bash rounds
+    # down, so add on 0.5% before we start so that the percentage gets rounded
+    # correctly. Bash doesn't do floating point arithmetic so need to multiply
+    # by 100 first then do the divisions.
     fd_perc=$((($fd_cur*100 + $fd_max/2)/$fd_max));
     echo $fd_perc;;
-  *)
-    exit 0;;
 esac
 exit 0
-
-

--- a/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
+++ b/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
@@ -33,9 +33,9 @@ else
   exit 0
 fi
 
-# Now that we know we've got something to return, pull out the file descriptor
-# stats and then work out which particular one to return.
-# The syntax is three lines of return:
+# Now that we know what we're meant to return, pull out the file descriptor
+# stats from file-nr and return the corresponding value.
+# The return syntax is three lines containing:
 #  <oid>
 #  <type>
 #  <value>

--- a/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
+++ b/clearwater-snmpd/usr/share/clearwater/infrastructure/scripts/snmpd_fd_handler
@@ -39,17 +39,19 @@ if [ "$1" = "-n" ]; then
     $oid_prefix.2.* | $oid_prefix.3 | $oid_prefix.3.0)
       oid_req=$oid_prefix.3.0;;
 
+    # No more entries - just return without text and it will be handled by snmpd.
     *)
-      # No more entries - just return without text and it will be handled by snmpd.
       exit 0;;
   esac
 elif [ "$1" = "-g" ]; then
   # It's an exact get so ensure that it matches one of our valid OIDs.
   case "$oid_req" in
     $oid_prefix.1.0 | $oid_prefix.2.0 | $oid_prefix.3.0)
-      # No matching entry - just return without text and it will be handled by snmpd.
       ;;
-    *) exit 0;;
+
+    # No matching entry - just return without text and it will be handled by snmpd.
+    *)
+      exit 0;;
   esac
 else
   # It's a set request - just return unwriteable


### PR DESCRIPTION

I've enhanced snmpd to expose file descriptor statistics from Clearwater MIBs. 

The bash script, snmpd_fd_handler, parses the request from SNMPD and works out which statistic is required before pulling the data off of proc and returning it. The definition of what each OID represents is in the MIB file that is part of a commit to clearwater-netsnmp-handlers.

The update to snmpd.conf ensures that we register the bash script for the relevant OIDs.

Testing has been live on an SPN. I haven't bothered with other node types.