### PR TITLE
[Reviewer:Richard] Allow INFORMs to be sent to non-standard ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build_setup/
 
 *.swp
+*.pyc
 *~
 
 debian/copyright

--- a/cw_infrastructure/cw_infrastructure/check_config_utilities.py
+++ b/cw_infrastructure/cw_infrastructure/check_config_utilities.py
@@ -41,24 +41,67 @@ def warning(option_name, message):
     sys.stderr.write("WARNING: {}: {}\n".format(option_name, message))
 
 
-def ip_version(value):
+def get_ip_and_port(value):
+    """Utility method to get the IP and (optional) port parts from a string.
+    """
+    if not value:
+        raise ValueError("No IP address specified")
+
+    if "." in value:
+        # IPv4 address with optional port.
+        elements = value.split(":")
+    else:
+        # IPv6 address. These are in the format:
+        # <IPv6> or [<IPv6>]:<port>
+        if value[0] == "[":
+            elements = value[1:].split("]:")
+        else:
+            elements = [value]
+
+    if len(elements) > 2:
+        # Too many port separators
+        raise ValueError("{} contained extra port separators".format(value))
+
+    addr = elements[0]
+    if len(elements) == 2:
+        port = int(elements[1])
+        if not 0 < port < (2 ** 16):
+            raise ValueError("{} port value invalid".format(port))
+    else:
+        port = None
+
+    return (addr, port)
+
+
+def ip_version(value, optional_port=False):
     """Return the IP version of the supplied IP address, which is passed as a
     string. If the argument is not an IP address this function returns None,
-    which is more convenient than raising an exception"""
+    which is more convenient than raising an exception. May optionally include 
+    a port if the optional_port parameter is set to True."""
+
+    if optional_port:
+        try:
+            (addr, port) = get_ip_and_port(value)
+        except ValueError:
+            return None
+    else:
+        addr = value
+
     try:
-        socket.inet_pton(socket.AF_INET, value)
+        socket.inet_pton(socket.AF_INET, addr)
         return 4
     except socket.error:
         try:
-            socket.inet_pton(socket.AF_INET6, value)
+            socket.inet_pton(socket.AF_INET6, addr)
             return 6
         except socket.error:
             return None
 
 
-def is_ip_addr(value):
-    """Return whether the supplied string is a valid IP address"""
-    return (ip_version(value) is not None)
+def is_ip_addr(value, optional_port=False):
+    """Return whether the supplied string is a valid IP address. Optionally 
+    permits a port."""
+    return (ip_version(value, optional_port) is not None)
 
 
 def is_domain_name(value):

--- a/cw_infrastructure/cw_infrastructure/check_config_utilities.py
+++ b/cw_infrastructure/cw_infrastructure/check_config_utilities.py
@@ -41,67 +41,25 @@ def warning(option_name, message):
     sys.stderr.write("WARNING: {}: {}\n".format(option_name, message))
 
 
-def get_ip_and_port(value):
-    """Utility method to get the IP and (optional) port parts from a string.
-    """
-    if not value:
-        raise ValueError("No IP address specified")
-
-    if "." in value:
-        # IPv4 address with optional port.
-        elements = value.split(":")
-    else:
-        # IPv6 address. These are in the format:
-        # <IPv6> or [<IPv6>]:<port>
-        if value[0] == "[":
-            elements = value[1:].split("]:")
-        else:
-            elements = [value]
-
-    if len(elements) > 2:
-        # Too many port separators
-        raise ValueError("{} contained extra port separators".format(value))
-
-    addr = elements[0]
-    if len(elements) == 2:
-        port = int(elements[1])
-        if not 0 < port < (2 ** 16):
-            raise ValueError("{} port value invalid".format(port))
-    else:
-        port = None
-
-    return (addr, port)
-
-
-def ip_version(value, optional_port=False):
+def ip_version(value):
     """Return the IP version of the supplied IP address, which is passed as a
     string. If the argument is not an IP address this function returns None,
-    which is more convenient than raising an exception. May optionally include 
-    a port if the optional_port parameter is set to True."""
-
-    if optional_port:
-        try:
-            (addr, port) = get_ip_and_port(value)
-        except ValueError:
-            return None
-    else:
-        addr = value
+    which is more convenient than raising an exception."""
 
     try:
-        socket.inet_pton(socket.AF_INET, addr)
+        socket.inet_pton(socket.AF_INET, value)
         return 4
     except socket.error:
         try:
-            socket.inet_pton(socket.AF_INET6, addr)
+            socket.inet_pton(socket.AF_INET6, value)
             return 6
         except socket.error:
             return None
 
 
-def is_ip_addr(value, optional_port=False):
-    """Return whether the supplied string is a valid IP address. Optionally 
-    permits a port."""
-    return (ip_version(value, optional_port) is not None)
+def is_ip_addr(value):
+    """Return whether the supplied string is a valid IP address."""
+    return (ip_version(value) is not None)
 
 
 def is_domain_name(value):

--- a/cw_infrastructure/cw_infrastructure/clearwater_options.py
+++ b/cw_infrastructure/cw_infrastructure/clearwater_options.py
@@ -35,11 +35,11 @@ class ClearwaterOptions:
             Option('sprout_hostname', Option.MANDATORY,
                    vlds.run_in_sig_ns(vlds.ip_or_domain_name_validator)),
             Option('hs_hostname', Option.MANDATORY,
-                   vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_with_port_validator)),
+                   vlds.run_in_sig_ns(vlds.ip_or_domain_name_with_port_validator)),
             Option('sprout_hostname_mgmt', Option.OPTIONAL,
-                   vlds.resolvable_ip_or_domain_name_with_port_validator),
+                   vlds.ip_or_domain_name_with_port_validator),
             Option('hs_hostname_mgmt', Option.OPTIONAL,
-                   vlds.resolvable_ip_or_domain_name_with_port_validator),
+                   vlds.ip_or_domain_name_with_port_validator),
 
             Option('homestead_diameter_watchdog_timer', Option.OPTIONAL,
                    vlds.create_integer_range_validator(min_value=6)),
@@ -56,7 +56,7 @@ class ClearwaterOptions:
             Option('hss_hostname', Option.OPTIONAL,
                    vlds.run_in_sig_ns(vlds.resolvable_domain_name_validator)),
             Option('hs_provisioning_hostname', Option.OPTIONAL,
-                   vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_with_port_validator)),
+                   vlds.run_in_sig_ns(vlds.ip_or_domain_name_with_port_validator)),
 
             Option('snmp_ip',
                    Option.SUGGESTED,
@@ -74,7 +74,7 @@ class ClearwaterOptions:
                    vlds.run_in_sig_ns(vlds.sip_uri_domain_name_validator)),
 
             Option('enum_server', Option.OPTIONAL,
-                   vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_list_validator)),
+                   vlds.run_in_sig_ns(vlds.ip_or_domain_name_list_validator)),
             Option('signaling_dns_server',
                    Option.OPTIONAL,
                    vlds.ip_addr_list_validator),
@@ -83,11 +83,11 @@ class ClearwaterOptions:
                    vlds.run_in_sig_ns(vlds.diameter_realm_validator)),
             Option('node_idx', Option.OPTIONAL, vlds.integer_validator),
             Option('ralf_hostname', Option.OPTIONAL,
-                   vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_with_port_validator)),
+                   vlds.run_in_sig_ns(vlds.ip_or_domain_name_with_port_validator)),
             Option('chronos_hostname', Option.OPTIONAL,
-                   vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_validator)),
+                   vlds.run_in_sig_ns(vlds.ip_or_domain_name_validator)),
             Option('xdms_hostname', Option.OPTIONAL,
-                   vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_with_port_validator)),
+                   vlds.run_in_sig_ns(vlds.ip_or_domain_name_with_port_validator)),
 
             Option('alias_list', Option.DEPRECATED),
             Option('always_serve_remote_aliases',
@@ -102,7 +102,7 @@ class ClearwaterOptions:
                 Option(
                     'cassandra_hostname',
                     Option.MANDATORY,
-                    vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_validator))
+                    vlds.run_in_sig_ns(vlds.ip_or_domain_name_validator))
             )
         return options
 

--- a/cw_infrastructure/cw_infrastructure/clearwater_options.py
+++ b/cw_infrastructure/cw_infrastructure/clearwater_options.py
@@ -60,7 +60,7 @@ class ClearwaterOptions:
 
             Option('snmp_ip',
                    Option.SUGGESTED,
-                   vlds.resolvable_ip_or_domain_name_list_validator),
+                   vlds.ip_or_domain_name_opt_port_list_validator),
             Option('sas_server', Option.SUGGESTED, sas_server_validator),
             Option('sas_use_signaling_interface',
                    Option.OPTIONAL,

--- a/cw_infrastructure/cw_infrastructure/clearwater_options.py
+++ b/cw_infrastructure/cw_infrastructure/clearwater_options.py
@@ -21,19 +21,19 @@ class ClearwaterOptions:
 
         # Setup the SAS server validator depending on whether signaling
         # namespace is to be used
-        sas_server_validator = vlds.resolvable_ip_or_domain_name_validator
+        sas_server_validator = vlds.ip_or_domain_name_validator
 
         if utils.get_option_value('sas_use_signaling_interface') == 'Y':
-            sas_server_validator = vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_validator)
+            sas_server_validator = vlds.run_in_sig_ns(vlds.ip_or_domain_name_validator)
 
         options = [
             Option('local_ip', Option.MANDATORY, vlds.ip_addr_validator),
             Option('public_ip', Option.MANDATORY, vlds.ip_addr_validator),
             Option('public_hostname', Option.MANDATORY,
-                   vlds.run_in_sig_ns(vlds.resolvable_domain_name_validator)),
+                   vlds.run_in_sig_ns(vlds.domain_name_validator)),
             Option('home_domain', Option.MANDATORY, vlds.domain_name_validator),
             Option('sprout_hostname', Option.MANDATORY,
-                   vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_validator)),
+                   vlds.run_in_sig_ns(vlds.ip_or_domain_name_validator)),
             Option('hs_hostname', Option.MANDATORY,
                    vlds.run_in_sig_ns(vlds.resolvable_ip_or_domain_name_with_port_validator)),
             Option('sprout_hostname_mgmt', Option.OPTIONAL,

--- a/cw_infrastructure/cw_infrastructure/test/validators_test.py
+++ b/cw_infrastructure/cw_infrastructure/test/validators_test.py
@@ -231,6 +231,22 @@ class TestIpAddrListValidator(unittest.TestCase):
                                          any_order=True)
         mock_error.assert_called_once_with('val', mock.ANY)
 
+class TestIpAddrListOptionalPortsValidator(unittest.TestCase):
+
+
+    # Test that the IP address list validator handles some standard cases
+    def test_ok(self):
+        ok_lists = ["1.2.3.4", "1.2.3.4:22,2.3.4.5:33", "1.2.3.4,2.3.4.5:22"]
+        for addr_list in ok_lists:
+            code = validators.ip_addr_and_optional_port_list_validator('val', addr_list)
+            self.assertEqual(code, check_config_utilities.OK, addr_list)
+
+    def test_error(self):
+        bad_lists = ["1.2.3.4:66666", "1.2.3.4:22;2.3.4.5:33", "1.2.3,2.3.4.5:22"]
+        for addr_list in bad_lists:
+            code = validators.ip_addr_and_optional_port_list_validator('val', addr_list)
+            self.assertEqual(code, check_config_utilities.ERROR, addr_list)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/cw_infrastructure/cw_infrastructure/test/validators_test.py
+++ b/cw_infrastructure/cw_infrastructure/test/validators_test.py
@@ -231,17 +231,36 @@ class TestIpAddrListValidator(unittest.TestCase):
                                          any_order=True)
         mock_error.assert_called_once_with('val', mock.ANY)
 
+
 class TestIpAddrDomainOptionalPortsListValidator(unittest.TestCase):
 
     # Test that the IP address list validator handles some standard cases
     def test_ok(self):
-        ok_lists = ["1.2.3.4", "1.2.3.4:22,2.3.4.5:33", "1.2.3.4,2.3.4.5:22"]
+        ok_lists = ["1.2.3.4", 
+                    "1.2.3.4:22,2.3.4.5:33", 
+                    "metaswitch.com",
+                    "metaswitch.com:33",
+                    "metaswitch.com:33,datcon.co.uk",
+                    "metaswitch.com:33,datcon.co.uk:25",
+                    "2002:AAAA:bb::101",
+                    "[2002:AAAA:bb::101]:1234",
+                    "[2002:AAAA:bb::101]:1234,2002:AAAA:bb::102",
+                    "1.2.3.4,2.3.4.5:22"]
         for addr_list in ok_lists:
             code = validators.ip_or_domain_name_opt_port_list_validator('val', addr_list)
             self.assertEqual(code, check_config_utilities.OK, "Got {} for {}".format(code, addr_list))
 
     def test_error(self):
-        bad_lists = ["1.2.3.4:66666", "1.2.3.4:22-2.3.4.5:33", "1.2.3,2.3.4.5:22"]
+        bad_lists = ["1.2.3.4:66666", 
+                     "1.2.3.4:22-2.3.4.5:33", 
+                     "metaswitchco/m",
+                     "metaswitch.c/om:33",
+                     "metaswitch.com:33,da/tcon.co.uk",
+                     "metaswitch.co%m:33,dat/con.co.uk:25",
+                     "2002:AAAA:Xbb::101",
+                     "[2002:AAAA:bb::101]:999999",
+                     "[2002:AAAA:bb::101]:1234,2002:AAAAA:bb::102",
+                     "1.2.3,2.3.4.5:22"]
         for addr_list in bad_lists:
             code = validators.ip_or_domain_name_opt_port_list_validator('val', addr_list)
             self.assertEqual(code, check_config_utilities.ERROR, "Got {} for {}".format(code, addr_list))

--- a/cw_infrastructure/cw_infrastructure/test/validators_test.py
+++ b/cw_infrastructure/cw_infrastructure/test/validators_test.py
@@ -231,21 +231,20 @@ class TestIpAddrListValidator(unittest.TestCase):
                                          any_order=True)
         mock_error.assert_called_once_with('val', mock.ANY)
 
-class TestIpAddrListOptionalPortsValidator(unittest.TestCase):
-
+class TestIpAddrDomainOptionalPortsListValidator(unittest.TestCase):
 
     # Test that the IP address list validator handles some standard cases
     def test_ok(self):
         ok_lists = ["1.2.3.4", "1.2.3.4:22,2.3.4.5:33", "1.2.3.4,2.3.4.5:22"]
         for addr_list in ok_lists:
-            code = validators.ip_addr_and_optional_port_list_validator('val', addr_list)
-            self.assertEqual(code, check_config_utilities.OK, addr_list)
+            code = validators.ip_or_domain_name_opt_port_list_validator('val', addr_list)
+            self.assertEqual(code, check_config_utilities.OK, "Got {} for {}".format(code, addr_list))
 
     def test_error(self):
-        bad_lists = ["1.2.3.4:66666", "1.2.3.4:22;2.3.4.5:33", "1.2.3,2.3.4.5:22"]
+        bad_lists = ["1.2.3.4:66666", "1.2.3.4:22-2.3.4.5:33", "1.2.3,2.3.4.5:22"]
         for addr_list in bad_lists:
-            code = validators.ip_addr_and_optional_port_list_validator('val', addr_list)
-            self.assertEqual(code, check_config_utilities.ERROR, addr_list)
+            code = validators.ip_or_domain_name_opt_port_list_validator('val', addr_list)
+            self.assertEqual(code, check_config_utilities.ERROR, "Got {} for {}".format(code, addr_list))
 
 
 if __name__ == '__main__':

--- a/cw_infrastructure/cw_infrastructure/validators.py
+++ b/cw_infrastructure/cw_infrastructure/validators.py
@@ -107,7 +107,7 @@ def ip_or_domain_name_opt_port_list_validator(name, value):
     """Validate a config option that should be a comma-separated list of IP
     addresses or domain name with optional ports"""
 
-    if not all(resolvable_ip_or_domain_name_opt_port_validator(name, addr) == \
+    if not all(ip_or_domain_name_opt_port_validator(name, addr) == \
                                         utils.OK for addr in value.split(',')):
         utils.error(name,
                     "{} is not a comma separated list of IP addrs/domains/ports".format(value))
@@ -135,7 +135,7 @@ def ip_or_domain_name_validator(name, value):
         return utils.OK
 
 
-def resolvable_ip_or_domain_name_validator(name, value):
+def ip_or_domain_name_validator(name, value):
     """Validate a config option that should be an IP address or a domain name
     that resolves with the current DNS setup"""
 
@@ -147,7 +147,7 @@ def resolvable_ip_or_domain_name_validator(name, value):
             utils.error(name, "{} is not a valid IPv6 address".format(ip))
             return utils.ERROR
 
-    elif utils.ip_version(value) == 4:
+    elif utils.ip_version(value):
         return utils.OK
 
     elif utils.is_domain_name(value):
@@ -176,7 +176,7 @@ def resolvable_domain_name_validator(name, value):
         return utils.ERROR
 
 
-def resolvable_ip_or_domain_name_list_validator(name, value):
+def ip_or_domain_name_list_validator(name, value):
     """
     Check whether a config option is a list of IP addresses, or domain names
     that resolve with the current DNS setup
@@ -291,7 +291,7 @@ def diameter_realm_validator(name, value):
     return utils.OK
 
 
-def resolvable_ip_or_domain_name_with_port_validator(name, value):
+def ip_or_domain_name_with_port_validator(name, value):
     """Validate a config option that should be a IP address or a
     resolvable domain name, followed by a port"""
     match = re.match(r"^(.*):(\d+)$", value)
@@ -306,19 +306,19 @@ def resolvable_ip_or_domain_name_with_port_validator(name, value):
         utils.error(name, "The port value ({}) is too large".format(port))
         return utils.ERROR
 
-    return resolvable_ip_or_domain_name_validator(name, stem)
+    return ip_or_domain_name_validator(name, stem)
 
 
-def resolvable_ip_or_domain_name_opt_port_validator(name, value):
+def ip_or_domain_name_opt_port_validator(name, value):
     """Validate a config option that should be an IP address or a
     resolvable domain name, followed by a port"""
 
     # If there's a . in the value then it's IPv4/domain so a : preceeds a port
     # Otherwise it's IPv6, so look for a ]: to determine if there's a port.
     if ("." in value and ":" in value) or "]:" in value:
-        return resolvable_ip_or_domain_name_with_port_validator(name, value)
+        return ip_or_domain_name_with_port_validator(name, value)
     else:
-        return resolvable_ip_or_domain_name_validator(name, value)
+        return ip_or_domain_name_validator(name, value)
 
 
 def run_validator_with_dns(validator, name, value, dns_server):

--- a/cw_infrastructure/cw_infrastructure/validators.py
+++ b/cw_infrastructure/cw_infrastructure/validators.py
@@ -103,6 +103,17 @@ def ip_addr_list_validator(name, value):
         return utils.OK
 
 
+def ip_addr_and_optional_port_list_validator(name, value):
+    """Validate a config option that should be a comma-separated list of IP
+    addresses with optional ports"""
+    if not all(utils.is_ip_addr(addr, optional_port=True) for addr in value.split(',')):
+        utils.error(name,
+                    "{} is not a comma separated list of IP addresses/ports".format(value))
+        return utils.ERROR
+    else:
+        return utils.OK
+
+
 def domain_name_validator(name, value):
     """Validate a config option that should be a domain name"""
     if not utils.is_domain_name(value):


### PR DESCRIPTION
Hi Richard,

Can you review this change to support INFORMs on non-standard ports. Change is in three parts:
- Add validator for lists of IP/domain with optional ports
- Modify snmp_ip to use the new validator
- Change the agent to parse out the ports where present (separate PR)


Testing
- Live testing with single and multiple IP addresses with ports specified
(completed before self-review - will do a final tyre kick after markups)
- UT with multiple 

Other thoughts:
- I've not mocked out the calls to the utils class like existing UTs have. That's because it feels more sensible to test the combined code here.
- I struggled to stick to the current naming convention because domain + ip addr + optional port was a lot of characters. Happy to have other suggestions.
- I've changed a UTILS.OK return code for a UTILS.ERROR return code. I think that's the right thing to do given we'll give errors if you pass in unresolving domain names or badly formatted IPv6. Seems an odd choice then to return OK for 1.2.3
- I thought of doing Hypothesis testing (mainly because it would be fun) but decided I couldn't quite justify it. Happy to be convinced that it would be worth it!