### PR TITLE
[Reviewer: Mat] Prevent bind9 being installed alongside Clearwater

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Homepage: http://projectclearwater.org/
 Package: clearwater-infrastructure
 Architecture: any
 Depends: dnsmasq, ntp, python2.7, python-setuptools, gnutls-bin, libzmq3, curl, python-virtualenv
+Conflicts: bind9
 Suggests: clearwater-auto-config, clearwater-auto-upgrade
 Recommends: clearwater-diags-monitor
 Description: Common infrastructure for all Clearwater servers


### PR DESCRIPTION
Mat,

bind9 is a DNS server, which binds to port 53. This conflicts with our configuration of dnsmasq, which means packages don't install correctly, which has been tripping up a user on the mailing list.

This change to our Debian control file forces bind9 to be uninstalled if clearwater-infrastructure is installed on a node.