### PR TITLE
[Reviewer: CJR] New socket factory script

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
@@ -15,6 +15,11 @@ import sys
 import json
 import os
 
+SAS_CONFIG_FILE = "/etc/clearwater/sas.json"
+
+SIGNALING_CFG_DIR = "/etc/clearwater-socket-factory/signaling.d"
+MANAGEMENT_CFG_DIR = "/etc/clearwater-socket-factory/management.d"
+
 def create_directory(path_to_create):
     if not os.path.exists(path_to_create):
         os.makedirs(path_to_create)
@@ -23,32 +28,35 @@ def delete_file(path_to_delete):
     if os.path.exists(path_to_delete):
         os.remove(path_to_delete)
 
-SAS_CONFIG_FILE = "/etc/clearwater/sas.json"
+def main(sas_use_signaling_namespace):
+    create_directory(SIGNALING_CFG_DIR)
+    create_directory(MANAGEMENT_CFG_DIR)
 
-SIGNALING_CFG_DIR = "/etc/clearwater-socket-factory/signaling.d"
-MANAGEMENT_CFG_DIR = "/etc/clearwater-socket-factory/management.d"
-
-create_directory(SIGNALING_CFG_DIR)
-create_directory(MANAGEMENT_CFG_DIR)
-
-sas_use_signaling_namespace = sys.argv[1]
-if sas_use_signaling_namespace is "Y":
-    file_to_write = SIGNALING_CFG_DIR + "/clearwater-infrastructure"
-    delete_file(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
-else:
-    file_to_write = MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"
-    delete_file(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
-
-if os.path.isfile(SAS_CONFIG_FILE):
-    with open(SAS_CONFIG_FILE, 'r') as config_file:
-        sas_json = json.load(config_file)
-        sas_servers_list = sas_json["sas_servers"]
-    if sas_servers_list:
-        with open(file_to_write, 'w') as whitelist_file:
-            for sas_server_dict in sas_servers_list:
-                whitelist_file.write(sas_server_dict['ip'] + '\n')
-    else:
-        delete_file(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+    # Ready the whitelist file to write to for the specfied namespace, and delete the
+    # un-needed namespace whitelist file.
+    if sas_use_signaling_namespace is "Y":
+        file_to_write = SIGNALING_CFG_DIR + "/clearwater-infrastructure"
         delete_file(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
-else:
-    raise IOError("File is missing or inaccessible: %s", SAS_CONFIG_FILE)
+    else:
+        file_to_write = MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"
+        delete_file(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+
+    # Print the list of SAS IPs in sas.json, each on a new line.
+    if os.path.isfile(SAS_CONFIG_FILE):
+        with open(SAS_CONFIG_FILE, 'r') as config_file:
+            sas_json = json.load(config_file)
+            sas_servers_list = sas_json["sas_servers"]
+        if sas_servers_list:
+            with open(file_to_write, 'w') as whitelist_file:
+                for sas_server_dict in sas_servers_list:
+                    whitelist_file.write(sas_server_dict['ip'] + '\n')
+        # Delete the whitelist files if no SAS IPs are configured.
+        else:
+            delete_file(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+            delete_file(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
+    else:
+        raise IOError("File is missing or inaccessible: %s", SAS_CONFIG_FILE)
+
+if __name__ == "__main__":  # pragma: no cover
+    main(sys.argv[1])
+

--- a/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
@@ -15,25 +15,29 @@ import sys
 import json
 import os
 
+def create_directory(path_to_create):
+    if not os.path.exists(path_to_create):
+        os.makedirs(path_to_create)
+
+def delete_file(path_to_delete):
+    if os.path.exists(path_to_delete):
+        os.remove(path_to_delete)
+
 SAS_CONFIG_FILE = "/etc/clearwater/sas.json"
 
 SIGNALING_CFG_DIR = "/etc/clearwater-socket-factory/signaling.d"
 MANAGEMENT_CFG_DIR = "/etc/clearwater-socket-factory/management.d"
 
-if not os.path.exists(SIGNALING_CFG_DIR):
-    os.makedirs(SIGNALING_CFG_DIR)
-if not os.path.exists(MANAGEMENT_CFG_DIR):
-    os.makedirs(MANAGEMENT_CFG_DIR)
+create_directory(SIGNALING_CFG_DIR)
+create_directory(MANAGEMENT_CFG_DIR)
 
 sas_use_signaling_namespace = sys.argv[1]
 if sas_use_signaling_namespace is "Y":
     file_to_write = SIGNALING_CFG_DIR + "/clearwater-infrastructure"
-    if os.path.exists(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"):
-        os.remove(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
+    delete_file(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
 else:
     file_to_write = MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"
-    if os.path.exists(SIGNALING_CFG_DIR + "/clearwater-infrastructure"):
-        os.remove(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+    delete_file(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
 
 if os.path.isfile(SAS_CONFIG_FILE):
     with open(SAS_CONFIG_FILE, 'r') as config_file:
@@ -44,9 +48,7 @@ if os.path.isfile(SAS_CONFIG_FILE):
             for sas_server_dict in sas_servers_list:
                 whitelist_file.write(sas_server_dict['ip'] + '\n')
     else:
-        if os.path.exists(SIGNALING_CFG_DIR + "/clearwater-infrastructure"):
-            os.remove(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
-        if os.path.exists(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"):
-            os.remove(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
+        delete_file(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+        delete_file(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
 else:
     raise IOError("File is missing or inaccessible: %s", SAS_CONFIG_FILE)

--- a/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
@@ -20,16 +20,20 @@ SAS_CONFIG_FILE = "/etc/clearwater/sas.json"
 SIGNALING_CFG_DIR = "/etc/clearwater-socket-factory/signaling.d"
 MANAGEMENT_CFG_DIR = "/etc/clearwater-socket-factory/management.d"
 
-os.makedirs(SIGNALING_CFG_DIR)
-os.makedirs(MANAGEMENT_CFG_DIR)
+if not os.path.exists(SIGNALING_CFG_DIR):
+    os.makedirs(SIGNALING_CFG_DIR)
+if not os.path.exists(MANAGEMENT_CFG_DIR):
+    os.makedirs(MANAGEMENT_CFG_DIR)
 
 sas_use_signaling_namespace = sys.argv[1]
 if sas_use_signaling_namespace is "Y":
     file_to_write = SIGNALING_CFG_DIR + "/clearwater-infrastructure"
-    os.remove(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
+    if os.path.exists(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"):
+        os.remove(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
 else:
     file_to_write = MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"
-    os.remove(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+    if os.path.exists(SIGNALING_CFG_DIR + "/clearwater-infrastructure"):
+        os.remove(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
 
 if os.path.isfile(SAS_CONFIG_FILE):
     with open(SAS_CONFIG_FILE, 'r') as config_file:
@@ -40,7 +44,9 @@ if os.path.isfile(SAS_CONFIG_FILE):
             for sas_server_dict in sas_servers_list:
                 whitelist_file.write(sas_server_dict['ip'] + '\n')
     else:
-        os.remove(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
-        os.remove(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
+        if os.path.exists(SIGNALING_CFG_DIR + "/clearwater-infrastructure"):
+            os.remove(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+        if os.path.exists(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"):
+            os.remove(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
 else:
     raise IOError("File is missing or inaccessible: %s", SAS_CONFIG_FILE)

--- a/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python2.7
+
+# @file sas_socket_factory.py
+#
+# Copyright (C) Metaswitch Networks 2018
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+#
+# Script that writes the contents of sas.json to the relevant whitelist file.
+
+import sys
+import json
+import os
+
+SAS_CONFIG_FILE = "/etc/clearwater/sas.json"
+
+SIGNALING_CFG_DIR = "/etc/clearwater-socket-factory/signaling.d"
+MANAGEMENT_CFG_DIR = "/etc/clearwater-socket-factory/management.d"
+
+os.system("mkdir -p " + SIGNALING_CFG_DIR)
+os.system("mkdir -p " + MANAGEMENT_CFG_DIR)
+
+sas_use_signaling_namespace = sys.argv[1]
+if sas_use_signaling_namespace is "Y":
+    file_to_write = SIGNALING_CFG_DIR + "/clearwater-infrastructure"
+    os.system("rm -f " + MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
+else:
+    file_to_write = MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"
+    os.system("rm -f " + SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+
+if os.path.isfile(SAS_CONFIG_FILE):
+    with open(SAS_CONFIG_FILE, 'r') as config_file:
+        sas_json = json.load(config_file)
+        sas_servers_list = sas_json["sas_servers"]
+    if sas_servers_list:
+        with open(file_to_write, 'w') as whitelist_file:
+            for sas_server_dict in sas_servers_list:
+                whitelist_file.write(sas_server_dict['ip'] + '\n')
+    else:
+        os.system("rm -f " + SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+        os.system("rm -f " + MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
+else:
+    raise IOError("File is missing or inaccessible: %s", SAS_CONFIG_FILE)

--- a/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
@@ -59,4 +59,3 @@ def main(sas_use_signaling_namespace):
 
 if __name__ == "__main__":  # pragma: no cover
     main(sys.argv[1])
-

--- a/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
@@ -20,16 +20,16 @@ SAS_CONFIG_FILE = "/etc/clearwater/sas.json"
 SIGNALING_CFG_DIR = "/etc/clearwater-socket-factory/signaling.d"
 MANAGEMENT_CFG_DIR = "/etc/clearwater-socket-factory/management.d"
 
-os.system("mkdir -p " + SIGNALING_CFG_DIR)
-os.system("mkdir -p " + MANAGEMENT_CFG_DIR)
+os.makedirs(SIGNALING_CFG_DIR)
+os.makedirs(MANAGEMENT_CFG_DIR)
 
 sas_use_signaling_namespace = sys.argv[1]
 if sas_use_signaling_namespace is "Y":
     file_to_write = SIGNALING_CFG_DIR + "/clearwater-infrastructure"
-    os.system("rm -f " + MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
+    os.remove(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
 else:
     file_to_write = MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"
-    os.system("rm -f " + SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+    os.remove(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
 
 if os.path.isfile(SAS_CONFIG_FILE):
     with open(SAS_CONFIG_FILE, 'r') as config_file:
@@ -40,7 +40,7 @@ if os.path.isfile(SAS_CONFIG_FILE):
             for sas_server_dict in sas_servers_list:
                 whitelist_file.write(sas_server_dict['ip'] + '\n')
     else:
-        os.system("rm -f " + SIGNALING_CFG_DIR + "/clearwater-infrastructure")
-        os.system("rm -f " + MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
+        os.remove(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
+        os.remove(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
 else:
     raise IOError("File is missing or inaccessible: %s", SAS_CONFIG_FILE)

--- a/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/sas_socket_factory.py
@@ -41,7 +41,8 @@ def main(sas_use_signaling_namespace):
         file_to_write = MANAGEMENT_CFG_DIR + "/clearwater-infrastructure"
         delete_file(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
 
-    # Print the list of SAS IPs in sas.json, each on a new line.
+    # Print the list of SAS IPs in sas.json, each on a new line. If no file is present,
+    # do no work.
     if os.path.isfile(SAS_CONFIG_FILE):
         with open(SAS_CONFIG_FILE, 'r') as config_file:
             sas_json = json.load(config_file)
@@ -54,8 +55,6 @@ def main(sas_use_signaling_namespace):
         else:
             delete_file(SIGNALING_CFG_DIR + "/clearwater-infrastructure")
             delete_file(MANAGEMENT_CFG_DIR + "/clearwater-infrastructure")
-    else:
-        raise IOError("File is missing or inaccessible: %s", SAS_CONFIG_FILE)
 
 if __name__ == "__main__":  # pragma: no cover
     main(sys.argv[1])

--- a/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/sas_socket_factory
+++ b/clearwater-infrastructure/usr/share/clearwater/infrastructure/scripts/sas_socket_factory
@@ -2,34 +2,14 @@
 
 # @file sas_socket_factory
 #
-# Copyright (C) Metaswitch Networks 2016
-# If license terms are provided to you in a COPYING file in the root directory
-# of the source code repository by which you are accessing this code, then
-# the license outlined in that COPYING file applies to your use.
-# Otherwise no rights are granted except for those provided to you by
-# Metaswitch Networks in a separate written agreement.
+# Copyright (C) Metaswitch Networks 2018
 
 # Create /etc/clearwater-socket-factory/management.d/clearwater-infrastructure
-# containing the node's SAS address for clearwater-socket-factory's management
+# containing the node's SAS addresses for clearwater-socket-factory's management
 # namespace whitelist. This allows Clearwater processes to connect to SAS.
-
-signaling_cfg_dir=/etc/clearwater-socket-factory/signaling.d
-management_cfg_dir=/etc/clearwater-socket-factory/management.d
-
-mkdir -p $signaling_cfg_dir
-mkdir -p $management_cfg_dir
+#
+# Creates /etc/clearwater-socket-factory/signaling.d/clearwater-infrastructure
+# instead if sas_use_signaling_interface is set to "Y" in shared_config.
 
 . /etc/clearwater/config
-
-if [ ! -z $sas_server ]; then
-  if [ "$sas_use_signaling_interface" == "Y" ]; then
-    echo "$sas_server" > $signaling_cfg_dir/clearwater-infrastructure
-    rm -f $management_cfg_dir/clearwater-infrastructure
-  else
-    echo "$sas_server" > $management_cfg_dir/clearwater-infrastructure
-    rm -f $signaling_cfg_dir/clearwater-infrastructure
-  fi
-else
-  rm -f $management_cfg_dir/clearwater-infrastructure
-  rm -f $signaling_cfg_dir/clearwater-infrastructure
-fi
+python /usr/share/clearwater/bin/sas_socket_factory.py "$sas_use_signaling_interface"


### PR DESCRIPTION
New sas_socket_factory script to interact with the new `sas.json` config file.

Writes the list of IP addresses present in `sas.jon` to either 

`/etc/clearwater-socket-factory/management.d/clearwater-infrastructure` 
or 
`/etc/clearwater-socket-factory/signaling.d/clearwater-infrastructure`  

depending on whether `sas_use_signaling_interface`  in `shared_config` is set to "Y". 