### PR TITLE
[Reviewer: Richard] Config validation dns timeout

### DIFF
--- a/cw_infrastructure/cw_infrastructure/check_config_utilities.py
+++ b/cw_infrastructure/cw_infrastructure/check_config_utilities.py
@@ -115,8 +115,8 @@ def is_domain_resolvable(name, rrtype):
         # lifetime is the time spent waiting for a response overall.
         # By setting timeout to 2 and lifetime to 4, we allow time for us to
         # check at least 2 of our DNS servers before we give up.
-        resolver.timeout = 2
-        resolver.lifetime = 4
+        resolver.timeout = 2.0
+        resolver.lifetime = 4.0
         answers = resolver.query(name, rrtype)
         return len(answers) != 0
 

--- a/cw_infrastructure/cw_infrastructure/check_config_utilities.py
+++ b/cw_infrastructure/cw_infrastructure/check_config_utilities.py
@@ -110,7 +110,13 @@ def is_domain_resolvable(name, rrtype):
 
     try:
         resolver = dns.resolver.get_default_resolver()
+
+        # timeout is the time spent waiting for each DNS server.
+        # lifetime is the time spent waiting for a response overall.
+        # By setting timeout to 2 and lifetime to 4, we allow time for us to
+        # check at least 2 of our DNS servers before we give up.
         resolver.timeout = 2
+        resolver.lifetime = 4
         answers = resolver.query(name, rrtype)
         return len(answers) != 0
 

--- a/cw_infrastructure/cw_infrastructure/validators.py
+++ b/cw_infrastructure/cw_infrastructure/validators.py
@@ -126,16 +126,6 @@ def domain_name_validator(name, value):
 
 
 def ip_or_domain_name_validator(name, value):
-    """Validate a config option that should be a domain name or IP address"""
-    if not utils.is_ip_addr(value) and not utils.is_domain_name(value):
-        utils.error(name,
-                    "{} is neither a valid IP address or domain name".format(value))
-        return utils.ERROR
-    else:
-        return utils.OK
-
-
-def ip_or_domain_name_validator(name, value):
     """Validate a config option that should be an IP address or a domain name
     that resolves with the current DNS setup"""
 


### PR DESCRIPTION
This is a part of the fix for: https://github.com/Metaswitch/clearwater-issues/issues/3691

2 things here:

1. As per the comment, we were setting a per-server timeout but not setting a lifetime on the DNS query, so it was actually taking 20s to fail if no DNS servers were responding. I've now set the lifetime to 4 (to allow at least 2 tries at 2s per try)

1. I've removed a duplicated function that wasn't used.

`make test` and `make verify` pass.