### PR TITLE
Prevent warnings if sas_server is missing

### DIFF
--- a/cw_infrastructure/cw_infrastructure/clearwater_options.py
+++ b/cw_infrastructure/cw_infrastructure/clearwater_options.py
@@ -61,7 +61,7 @@ class ClearwaterOptions:
             Option('snmp_ip',
                    Option.SUGGESTED,
                    vlds.ip_or_domain_name_opt_port_list_validator),
-            Option('sas_server', Option.SUGGESTED, sas_server_validator),
+            Option('sas_server', Option.OPTIONAL, sas_server_validator),
             Option('sas_use_signaling_interface',
                    Option.OPTIONAL,
                    vlds.yes_no_validator),


### PR DESCRIPTION
As we use sas.json to configure SAS, we no longer suggest that sas_server is set in shared config.
I've left sas_server present in configlint.py and I've left the validators in place as we use the value of the fiels in the migration process in: https://github.com/Metaswitch/clearwater-etcd-plugins/pull/61

