### PR TITLE
[Reviewer: Seb] Pin setuptools to working version

### DIFF
--- a/clearwater-infrastructure/PyZMQ/Makefile
+++ b/clearwater-infrastructure/PyZMQ/Makefile
@@ -10,8 +10,9 @@ X86_64_ONLY=0
 
 PIP_VERSION := 9.0.1
 BUILDOUT_VERSION := 2.11.0
+SETUPTOOLS_VERSION := 38
 
-MARKER_FILE := ${ENV_DIR}/.pip_${PIP_VERSION}_buildout_${BUILDOUT_VERSION}
+MARKER_FILE := ${ENV_DIR}/.pip_${PIP_VERSION}_buildout_${BUILDOUT_VERSION}_setuptools_${SETUPTOOLS_VERSION}
 
 build: ${MARKER_FILE} buildout.cfg
 ifeq (${X86_64_ONLY},1)
@@ -24,7 +25,7 @@ ${MARKER_FILE}:
 	rm -rf _env
 	virtualenv --no-site-packages --python=${PYTHON_BIN} ${ENV_DIR}
 	mkdir -p .buildout_downloads/dist
-	${ENV_DIR}/bin/pip install --upgrade "pip==${PIP_VERSION}"
+	${ENV_DIR}/bin/pip install --upgrade "pip==${PIP_VERSION}" "setuptools==${SETUPTOOLS_VERSION}"
 	${ENV_DIR}/bin/pip install "zc.buildout==${BUILDOUT_VERSION}"
 	touch $@
 


### PR DESCRIPTION
Seb,

This fixes a build issue with clearwater-infrastructure.

If the latest virtualenv is installed, when we create the virtualenv it will, by default have the latest version of setuptools (as the default has switched from not downloading from PyPI to downloading from PyPI).

If we have the latest version of setuptools (V39) it has commit https://github.com/pypa/setuptools/commit/eeeb9b27fa48fccf2b5d52919eff1c75c4ad1718. This commit breaks `zc.buildout`.

`zc.buildout` has a dependency on setuptools (unknown to me when I previously fixed this build in https://github.com/Metaswitch/clearwater-infrastructure/pull/537). I thought it didn't, because when I last changed this, I ran `pip freeze` to check what was is installed in the working venv. However, `pip freeze` doesn't list setuptools by default....

I've pinned setuptools to version 38 on the basis that works. I could upgrade zc.buildout instead I suspect, but that feels more likely to break something (given we know that previous versions of setuptools do work for our use case).