### PR TITLE
[Reviewer: Ellie] Hide messy output of cw-run_in_signaling_namespace

### DIFF
--- a/clearwater-infrastructure/usr/share/clearwater/bin/run-in-signaling-namespace
+++ b/clearwater-infrastructure/usr/share/clearwater/bin/run-in-signaling-namespace
@@ -11,6 +11,8 @@
 
 . /usr/share/clearwater/utils/check-root-permissions 1
 
+trap '' SIGABRT
+
 # Returns the namespace_prefix (only set if the signaling_namespace is in use).
 . /etc/clearwater/config
 [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"


### PR DESCRIPTION
Hi Ellie, could you review this fix for me please?

This fix hides messy bash output when a command prefixed with "cw-run_in_signaling_namespace" aborts due to an error. 
For example, running `cw-run_in_signaling_namespace tcpdump host 10.77.186.201` displays the following bash error:
```
/usr/share/clearwater/bin/run-in-signaling-namespace: line 17: 23303 Aborted                 (core dumped) $namespace_prefix "$@"
```
With my fix in place, this output is replaced by the following:
```
Aborted (core dumped)
```
I have live tested the fix on our l3-cc3 test deployment.